### PR TITLE
feat(cloud): M7 P1+P2+P4+P6 pychronAPI workstation onboarding

### DIFF
--- a/docs/architecture/forgejo-cloud-onboarding.md
+++ b/docs/architecture/forgejo-cloud-onboarding.md
@@ -1,0 +1,142 @@
+# Forgejo Cloud Workstation Onboarding (M7)
+
+Plan for wiring the Pychron desktop client into the Forgejo + bot-user
+workflow shipped in `pychronAPI` M0–M6 + M8.
+
+Single lab per workstation. No multi-lab switching. Re-onboarding to a
+different lab is a destructive wipe + redo.
+
+## Server contract (already shipped in pychronAPI)
+
+- `POST /api/v1/forgejo/workstations/ssh-keys` — register SSH public key,
+  returns `bot_username`, `fingerprint`, `default_metadata_repo`,
+  `ssh_host_alias { alias, real_host, port, known_hosts_line }`.
+  Requires API token with scope `workstations:register_ssh_key`.
+  Bootstrap and superuser tokens are 403'd (M3).
+- `GET /api/v1/forgejo/labs/{name}/default-metadata-repo` — returns
+  `repository_identifier`, `ssh_url`, `https_url`, `branch`.
+- `GET /api/v1/forgejo/whoami` — token introspection (kind, scopes,
+  lab).
+- API tokens shaped `pcy_<lab>_<random>`.
+
+## Layout on disk
+
+| Path | Purpose |
+|------|---------|
+| `~/.pychron/keys/pychron_<host>` | ed25519 private key, 0600 |
+| `~/.pychron/keys/pychron_<host>.pub` | public key |
+| `~/.pychron/known_hosts` | scoped known_hosts file |
+| `~/Pychron/MetaData` | clone of lab default MetaData repo |
+| `~/Pychron/projects/<repo>` | per-project DVC clones |
+
+API token lives in OS keyring (`keyring` lib). Lab name and base URL live
+in the existing prefs `.cfg`.
+
+## Milestones
+
+### P1 — Settings model + secret storage
+
+- New prefs pane "Pychron Cloud" under existing prefs framework.
+- Fields: `api_base_url`, `lab_name`, `api_token`.
+- Token stored via OS keyring; never plaintext in `.cfg`.
+- On save, ping `GET /api/v1/forgejo/whoami`; reject on 401 and
+  surface the returned scopes so the user can confirm the token can
+  actually register a key.
+
+### P2 — SSH key lifecycle
+
+New service: `pychron/forgejo/workstation_setup.py`.
+
+- Generate ed25519 keypair at `~/.pychron/keys/pychron_<host>` if
+  missing; perms 0600.
+- Read public key, POST to `/api/v1/forgejo/workstations/ssh-keys`.
+- Persist response: `bot_username`, `fingerprint`, `ssh_host_alias`
+  block.
+- Append `known_hosts_line` to `~/.pychron/known_hosts`.
+- Append SSH host block to `~/.ssh/config` keyed by alias:
+
+  ```
+  Host pychron-<lab>
+      HostName <real_host>
+      Port <port>
+      User git
+      IdentityFile ~/.pychron/keys/pychron_<host>
+      IdentitiesOnly yes
+      UserKnownHostsFile ~/.pychron/known_hosts
+  ```
+
+- Idempotent: re-running rotates only when the local key is missing or
+  the server rejects it (e.g. fingerprint not registered).
+- Cross-platform SSH config path: `%USERPROFILE%\.ssh\config` on
+  Windows; require OpenSSH for Windows or fall back to embedded git's
+  ssh.
+
+### P3 — MetaData repo bootstrap
+
+- After P2, fetch `/api/v1/forgejo/labs/{name}/default-metadata-repo`.
+- Clone via `git clone pychron-<lab>:<repository_identifier>.git
+  ~/Pychron/MetaData` if not present.
+- Replace existing pychron MetaData path resolution to point at this
+  clone — single source of truth, no per-experiment metadata copy.
+- Pull-on-start policy is configurable in prefs: always / daily / manual.
+  Default: daily.
+
+### P4 — DVC repo discovery
+
+- Repo picker in UI: "Open Project" → list of repos under
+  `<forgejo_org>` scoped to the configured lab.
+- Cache last-used in prefs.
+- Clone on first open under `~/Pychron/projects/<repo>`.
+- Push/pull via `pychron-<lab>` alias — no per-repo auth.
+
+> **Dependency on pychronAPI:** assumes a `GET
+> /api/v1/forgejo/labs/{name}/repositories` endpoint exists. If
+> missing, file as M9 follow-up in `pychronAPI` before starting P4.
+
+### P5 — Migration tool for existing labs (NMGRL)
+
+- Wizard: import existing local MetaData and push to lab MetaData repo.
+- Detect existing `.git` repos under user data dir, register them via
+  `POST /api/v1/forgejo/repositories/register` (or whichever endpoint
+  ships) so they appear in the cloud project list.
+- Dry-run mode: print plan, no writes.
+
+### P6 — Token rotation, revocation, re-onboarding
+
+- "Re-onboard workstation" button in prefs → re-runs P2, rotates SSH
+  key, replaces server-side row.
+- "Revoke this workstation" → calls token revoke endpoint; cascade kills
+  the SSH key per M3.
+- "Switch lab" is destructive: wipes prefs, key, known_hosts entry, and
+  `~/Pychron/MetaData` + `~/Pychron/projects/`. Requires explicit
+  confirmation. Then re-runs P1–P3 against the new lab.
+- Any 401 from the API: prompt for fresh token, do not silently retry.
+
+### P7 — Tests + dogfood on NMGRL
+
+- pytest fixtures stubbing pychronAPI responses for P1–P3.
+- Manual QA matrix: macOS / Windows / Linux. Keyring backends and SSH
+  config locations differ.
+- Roll out one NMGRL workstation at a time; verify the reaper (M8) sees
+  no orphans after each.
+
+## Order
+
+P1 → P2 → P3 land as separate PRs, each behind feature flag
+`enable_pychron_cloud`. P4–P5 follow. P6 lands alongside P2. P7 runs
+continuously.
+
+## Coupling with pychronAPI
+
+- P4 may need a new endpoint
+  `GET /api/v1/forgejo/labs/{name}/repositories`. File the ticket in
+  `pychronAPI` before starting P4.
+- Reaper events (M8) already log SSH key deletions; no client change
+  needed.
+
+## Out of scope
+
+- Multi-lab on the same workstation.
+- Switching the active lab without wiping local state.
+- HTTPS clones — SSH alias is the only supported transport for
+  workstation flows.

--- a/docs/architecture/forgejo-cloud-onboarding.md
+++ b/docs/architecture/forgejo-cloud-onboarding.md
@@ -126,6 +126,23 @@ P1 → P2 → P3 land as separate PRs, each behind feature flag
 `enable_pychron_cloud`. P4–P5 follow. P6 lands alongside P2. P7 runs
 continuously.
 
+## Bridge retirement
+
+The M0–M6 `BridgeService` (`pychron/git/hosts/bridge.py`) and
+`BridgePlugin` are functionally superseded by P3–P5. They are marked
+DEPRECATED in M7 P1 but kept for rollout overlap. Retire after:
+
+- P5 ships (repo register + migration).
+- pychronAPI exposes equivalent metadata fields on register
+  (`instrument`, `project`, `principal_investigator`, `irradiation`,
+  `material`).
+- Dogfood on NMGRL confirms no regressions.
+
+Removing means deleting `pychron/git/hosts/bridge.py`,
+`pychron/git/hosts/_bridge_client.py`, `pychron/git/tasks/bridge_plugin.py`,
+`pychron/git/tasks/bridge_preferences.py`, and dropping `BridgePlugin`
+from `pychron/envisage/pychron_run.py`.
+
 ## Coupling with pychronAPI
 
 - P4 may need a new endpoint

--- a/pychron/cloud/__init__.py
+++ b/pychron/cloud/__init__.py
@@ -1,0 +1,15 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================

--- a/pychron/cloud/api_client.py
+++ b/pychron/cloud/api_client.py
@@ -1,0 +1,364 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Minimal client for pychronAPI Forgejo workstation onboarding.
+
+P1 only exposes ``whoami`` so the preferences pane can validate that the
+user-supplied token can actually be used to register an SSH key. P2 will
+add the ``ssh-keys`` registration call.
+"""
+
+from __future__ import absolute_import
+
+import requests
+
+from pychron.globals import globalv
+
+
+DEFAULT_TIMEOUT = 10
+
+
+class CloudAPIError(Exception):
+    """Base error for pychronAPI calls."""
+
+
+class CloudAuthError(CloudAPIError):
+    """Token rejected (401)."""
+
+
+class CloudPermissionError(CloudAPIError):
+    """Token authenticated but lacks scope (403)."""
+
+
+class CloudFingerprintRejected(CloudAPIError):
+    """Server rejected the public key (e.g. duplicate fingerprint).
+
+    Caller is expected to rotate the local keypair and retry.
+    """
+
+
+class CloudNetworkError(CloudAPIError):
+    """Transport-level failure (DNS, TCP, TLS, timeout, non-JSON body)."""
+
+
+class WhoAmI(object):
+    """Result of ``GET /api/v1/forgejo/whoami``."""
+
+    __slots__ = ("kind", "scopes", "lab", "raw")
+
+    def __init__(self, kind, scopes, lab, raw):
+        self.kind = kind
+        self.scopes = list(scopes or [])
+        self.lab = lab
+        self.raw = raw
+
+    def has_scope(self, scope):
+        return scope in self.scopes
+
+    def can_register_ssh_key(self):
+        return self.has_scope("workstations:register_ssh_key")
+
+
+def _join(base_url, path):
+    return base_url.rstrip("/") + path
+
+
+def whoami(base_url, token, timeout=DEFAULT_TIMEOUT):
+    """Call ``GET /api/v1/forgejo/whoami`` and return :class:`WhoAmI`.
+
+    Raises :class:`CloudAuthError` on 401, :class:`CloudNetworkError` on
+    transport/decode failure, and :class:`CloudAPIError` on any other
+    non-2xx response.
+    """
+    if not base_url:
+        raise CloudAPIError("api_base_url is empty")
+    if not token:
+        raise CloudAuthError("api_token is empty")
+
+    url = _join(base_url, "/api/v1/forgejo/whoami")
+    headers = {
+        "Authorization": "Bearer {}".format(token),
+        "Accept": "application/json",
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=timeout, verify=globalv.cert_file)
+    except requests.RequestException as exc:
+        raise CloudNetworkError("whoami transport failure: {}".format(exc))
+
+    if resp.status_code == 401:
+        raise CloudAuthError("token rejected (401)")
+    if resp.status_code != 200:
+        raise CloudAPIError("whoami returned HTTP {}: {}".format(resp.status_code, resp.text[:200]))
+
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise CloudNetworkError("whoami returned non-JSON body: {}".format(exc))
+
+    return WhoAmI(
+        kind=body.get("kind", ""),
+        scopes=body.get("scopes", []),
+        lab=body.get("lab", ""),
+        raw=body,
+    )
+
+
+class SSHKeyRegistration(object):
+    """Result of ``POST /api/v1/forgejo/workstations/ssh-keys``.
+
+    Mirrors the M3 server contract: the bot user is opaque to the
+    workstation; the alias block is the only thing the client uses to
+    rewrite ``~/.ssh/config``.
+    """
+
+    __slots__ = (
+        "bot_username",
+        "fingerprint",
+        "default_metadata_repo",
+        "ssh_host_alias",
+        "raw",
+    )
+
+    def __init__(
+        self,
+        bot_username,
+        fingerprint,
+        default_metadata_repo,
+        ssh_host_alias,
+        raw,
+    ):
+        self.bot_username = bot_username
+        self.fingerprint = fingerprint
+        self.default_metadata_repo = default_metadata_repo
+        self.ssh_host_alias = ssh_host_alias or {}
+        self.raw = raw
+
+    @property
+    def alias(self):
+        return self.ssh_host_alias.get("alias", "")
+
+    @property
+    def real_host(self):
+        return self.ssh_host_alias.get("real_host", "")
+
+    @property
+    def port(self):
+        return self.ssh_host_alias.get("port", 22)
+
+    @property
+    def known_hosts_line(self):
+        return self.ssh_host_alias.get("known_hosts_line", "")
+
+
+class Repository(object):
+    """One row from ``GET /api/v1/forgejo/labs/{name}/repositories`` (P4)."""
+
+    __slots__ = (
+        "repository_identifier",
+        "ssh_url",
+        "https_url",
+        "default_branch",
+        "description",
+        "raw",
+    )
+
+    def __init__(
+        self,
+        repository_identifier,
+        ssh_url,
+        https_url,
+        default_branch="main",
+        description="",
+        raw=None,
+    ):
+        self.repository_identifier = repository_identifier
+        self.ssh_url = ssh_url
+        self.https_url = https_url
+        self.default_branch = default_branch or "main"
+        self.description = description or ""
+        self.raw = raw or {}
+
+
+def list_repositories(base_url, token, lab_name, timeout=DEFAULT_TIMEOUT):
+    """GET ``/api/v1/forgejo/labs/{lab_name}/repositories``.
+
+    Returns a list of :class:`Repository`. Server contract assumed (see
+    plan note in ``docs/architecture/forgejo-cloud-onboarding.md`` —
+    file as M9 prereq if missing).
+
+    Maps ``404`` on the lab to an empty list rather than an exception so
+    the UI can show a "no repos yet" state without distinguishing
+    transport vs. empty.
+    """
+    if not base_url:
+        raise CloudAPIError("api_base_url is empty")
+    if not token:
+        raise CloudAuthError("api_token is empty")
+    if not lab_name:
+        raise CloudAPIError("lab_name is empty")
+
+    url = _join(base_url, "/api/v1/forgejo/labs/{}/repositories".format(lab_name))
+    headers = {
+        "Authorization": "Bearer {}".format(token),
+        "Accept": "application/json",
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=timeout, verify=globalv.cert_file)
+    except requests.RequestException as exc:
+        raise CloudNetworkError("list_repositories transport failure: {}".format(exc))
+
+    if resp.status_code == 401:
+        raise CloudAuthError("token rejected (401)")
+    if resp.status_code == 403:
+        raise CloudPermissionError("token lacks scope to list repos (403)")
+    if resp.status_code == 404:
+        return []
+    if resp.status_code != 200:
+        raise CloudAPIError(
+            "list_repositories returned HTTP {}: {}".format(resp.status_code, resp.text[:200])
+        )
+
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise CloudNetworkError("list_repositories returned non-JSON body: {}".format(exc))
+
+    items = body.get("repositories", body) if isinstance(body, dict) else body
+    if not isinstance(items, list):
+        raise CloudNetworkError("list_repositories payload is not a list: {!r}".format(type(items)))
+
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            Repository(
+                repository_identifier=item.get("repository_identifier", "") or item.get("name", ""),
+                ssh_url=item.get("ssh_url", "") or item.get("clone_url_ssh", ""),
+                https_url=item.get("https_url", "") or item.get("clone_url_https", ""),
+                default_branch=item.get("default_branch", "main"),
+                description=item.get("description", ""),
+                raw=item,
+            )
+        )
+    return out
+
+
+def register_ssh_key(base_url, token, public_key, title=None, timeout=DEFAULT_TIMEOUT):
+    """POST a workstation public key to pychronAPI.
+
+    ``public_key`` must be a single OpenSSH-format line (``ssh-ed25519
+    <base64> <comment>``). ``title`` is an optional server-side label
+    for the key — defaults to the comment field of the public key.
+
+    Maps server status codes to typed errors:
+
+    - 200/201 → :class:`SSHKeyRegistration`
+    - 401 → :class:`CloudAuthError`
+    - 403 → :class:`CloudPermissionError`
+    - 409/422 (duplicate / unusable key) → :class:`CloudFingerprintRejected`
+    - other 4xx/5xx → :class:`CloudAPIError`
+    - transport / non-JSON → :class:`CloudNetworkError`
+    """
+    if not base_url:
+        raise CloudAPIError("api_base_url is empty")
+    if not token:
+        raise CloudAuthError("api_token is empty")
+    if not public_key:
+        raise CloudAPIError("public_key is empty")
+
+    url = _join(base_url, "/api/v1/forgejo/workstations/ssh-keys")
+    headers = {
+        "Authorization": "Bearer {}".format(token),
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    payload = {"public_key": public_key.strip()}
+    if title:
+        payload["title"] = title
+
+    try:
+        resp = requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+            verify=globalv.cert_file,
+        )
+    except requests.RequestException as exc:
+        raise CloudNetworkError("ssh-key register transport failure: {}".format(exc))
+
+    if resp.status_code == 401:
+        raise CloudAuthError("token rejected (401)")
+    if resp.status_code == 403:
+        raise CloudPermissionError("token lacks workstations:register_ssh_key scope (403)")
+    if resp.status_code in (409, 422):
+        raise CloudFingerprintRejected(
+            "server rejected key (HTTP {}): {}".format(resp.status_code, resp.text[:200])
+        )
+    if resp.status_code not in (200, 201):
+        raise CloudAPIError(
+            "ssh-key register returned HTTP {}: {}".format(resp.status_code, resp.text[:200])
+        )
+
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise CloudNetworkError("ssh-key register returned non-JSON body: {}".format(exc))
+
+    return SSHKeyRegistration(
+        bot_username=body.get("bot_username", ""),
+        fingerprint=body.get("fingerprint", ""),
+        default_metadata_repo=body.get("default_metadata_repo", ""),
+        ssh_host_alias=body.get("ssh_host_alias") or {},
+        raw=body,
+    )
+
+
+def revoke_workstation_token(base_url, token, timeout=DEFAULT_TIMEOUT):
+    """Revoke the calling token via ``DELETE /api/v1/forgejo/tokens/self``.
+
+    Server cascades the revocation to the registered SSH key (M8 reaper).
+    Returns True on a 2xx; treats 401 / 404 as already-revoked (idempotent
+    revoke) and returns True so the caller can proceed with local
+    cleanup. Other non-2xx → :class:`CloudAPIError`.
+    """
+    if not base_url:
+        raise CloudAPIError("api_base_url is empty")
+    if not token:
+        # Nothing to revoke — treat as success so the caller can still
+        # wipe local state.
+        return True
+
+    url = _join(base_url, "/api/v1/forgejo/tokens/self")
+    headers = {
+        "Authorization": "Bearer {}".format(token),
+        "Accept": "application/json",
+    }
+    try:
+        resp = requests.delete(url, headers=headers, timeout=timeout, verify=globalv.cert_file)
+    except requests.RequestException as exc:
+        raise CloudNetworkError("revoke transport failure: {}".format(exc))
+
+    if 200 <= resp.status_code < 300:
+        return True
+    if resp.status_code in (401, 404):
+        # Token already invalid or unknown — server-side state is what
+        # we wanted anyway.
+        return True
+    raise CloudAPIError("revoke returned HTTP {}: {}".format(resp.status_code, resp.text[:200]))
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/keyring_store.py
+++ b/pychron/cloud/keyring_store.py
@@ -1,0 +1,73 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""OS keyring-backed storage for the Pychron Cloud (pychronAPI) token.
+
+The pychronAPI bearer token is treated as a secret. It is stored in the
+host OS keyring (Keychain / Credential Manager / Secret Service) keyed by
+lab name so a workstation can be re-onboarded to a different lab without
+clobbering the prior credential atomically — re-onboarding is a separate
+destructive flow that calls :func:`delete_token` explicitly.
+"""
+
+from __future__ import absolute_import
+
+import logging
+
+import keyring
+from keyring.errors import KeyringError
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "pychron.cloud"
+DEFAULT_ACCOUNT = "default"
+
+
+def _account(lab_name):
+    lab_name = (lab_name or "").strip()
+    return lab_name or DEFAULT_ACCOUNT
+
+
+def get_token(lab_name):
+    """Return the stored token for ``lab_name`` or empty string."""
+    try:
+        return keyring.get_password(SERVICE_NAME, _account(lab_name)) or ""
+    except KeyringError as exc:
+        logger.warning("keyring get_password failed: %s", exc)
+        return ""
+
+
+def set_token(lab_name, token):
+    """Store ``token`` for ``lab_name``. Empty token is a no-op (use delete)."""
+    if not token:
+        return False
+    try:
+        keyring.set_password(SERVICE_NAME, _account(lab_name), token)
+        return True
+    except KeyringError as exc:
+        logger.warning("keyring set_password failed: %s", exc)
+        return False
+
+
+def delete_token(lab_name):
+    """Remove the token for ``lab_name``. Idempotent."""
+    try:
+        keyring.delete_password(SERVICE_NAME, _account(lab_name))
+        return True
+    except KeyringError:
+        return False
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/paths.py
+++ b/pychron/cloud/paths.py
@@ -1,0 +1,98 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Filesystem layout for the Pychron Cloud workstation onboarding (M7).
+
+| Path                                | Purpose                              |
+|-------------------------------------|--------------------------------------|
+| ``~/.pychron/keys/pychron_<host>``  | ed25519 private key, mode 0600       |
+| ``~/.pychron/keys/pychron_<host>.pub`` | public key                       |
+| ``~/.pychron/known_hosts``          | scoped known_hosts file              |
+| ``~/.pychron/registration.json``    | last server response (idempotency)   |
+| ``~/.ssh/config``                   | system SSH config (block-managed)    |
+
+All paths root at the user's home directory so re-onboarding is purely
+local-state surgery; nothing in :mod:`pychron.paths.appdata_dir` is
+touched. Cross-platform: ``os.path.expanduser`` resolves ``~`` to
+``%USERPROFILE%`` on Windows and ``$HOME`` elsewhere.
+"""
+
+from __future__ import absolute_import
+
+import os
+import socket
+
+
+def pychron_dir():
+    return os.path.expanduser(os.path.join("~", ".pychron"))
+
+
+def projects_dir():
+    """Return ``~/Pychron/projects`` — root for per-repo DVC clones (P4)."""
+    return os.path.expanduser(os.path.join("~", "Pychron", "projects"))
+
+
+def project_clone_path(repo_name):
+    return os.path.join(projects_dir(), repo_name)
+
+
+def keys_dir():
+    return os.path.join(pychron_dir(), "keys")
+
+
+def known_hosts_path():
+    return os.path.join(pychron_dir(), "known_hosts")
+
+
+def registration_path():
+    return os.path.join(pychron_dir(), "registration.json")
+
+
+def ssh_config_path():
+    return os.path.expanduser(os.path.join("~", ".ssh", "config"))
+
+
+def host_slug():
+    """Return a filesystem-safe slug derived from the local hostname."""
+    raw = socket.gethostname() or "workstation"
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in raw)
+
+
+def key_path(host=None):
+    h = host or host_slug()
+    return os.path.join(keys_dir(), "pychron_{}".format(h))
+
+
+def public_key_path(host=None):
+    return key_path(host) + ".pub"
+
+
+def ensure_pychron_dirs():
+    """Create ``~/.pychron`` and ``~/.pychron/keys`` if missing.
+
+    The keys directory is locked down to mode 0700 on POSIX so secrets
+    are not world-readable even before the keypair is written. No-op on
+    Windows where POSIX mode bits do not apply.
+    """
+    pdir = pychron_dir()
+    kdir = keys_dir()
+    os.makedirs(kdir, exist_ok=True)
+    if os.name == "posix":
+        os.chmod(pdir, 0o700)
+        os.chmod(kdir, 0o700)
+    return kdir
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/projects.py
+++ b/pychron/cloud/projects.py
@@ -1,0 +1,131 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Project (DVC repo) clone / pull manager for Pychron Cloud (M7 P4).
+
+Per the M7 plan, per-project DVC clones live under
+``~/Pychron/projects/<repo>``. Clone is via ``pychron-<lab>:owner/repo.git``
+so transport reuses the SSH alias dropped by P2; no per-repo auth.
+
+The functions here are deliberately thin wrappers around git so the
+heavy lifting stays in :mod:`git` (already a dependency). This module
+owns:
+
+- destination path resolution
+- "is this directory a clone of the right remote" check
+- clone-or-pull idempotency
+"""
+
+from __future__ import absolute_import
+
+import logging
+import os
+
+from git import GitCommandError, Repo
+from git.exc import InvalidGitRepositoryError, NoSuchPathError
+
+from pychron.cloud.paths import project_clone_path, projects_dir
+from pychron.cloud.url_rewrite import rewrite_to_alias
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectCloneError(Exception):
+    """Raised when a clone or pull cannot complete."""
+
+
+def ensure_projects_dir():
+    pdir = projects_dir()
+    os.makedirs(pdir, exist_ok=True)
+    return pdir
+
+
+def is_clone_of(path, expected_url):
+    """Return True if ``path`` is a git repo whose origin matches ``expected_url``.
+
+    Compared as raw strings — the caller is responsible for normalizing
+    URLs (e.g. via :func:`rewrite_to_alias`) before passing them in.
+    """
+    try:
+        repo = Repo(path)
+    except (InvalidGitRepositoryError, NoSuchPathError):
+        return False
+    try:
+        origin = repo.remote("origin")
+    except ValueError:
+        return False
+    urls = list(origin.urls)
+    return expected_url in urls
+
+
+def clone_or_pull(repo_name, ssh_url, alias, branch=None):
+    """Ensure ``~/Pychron/projects/<repo_name>`` is a clone of ``ssh_url``.
+
+    The URL is rewritten through ``alias`` so transport rides the
+    workstation's ``Host pychron-<lab>`` SSH config block.
+
+    Behaviour:
+
+    - Missing destination → clone.
+    - Existing clone with matching origin → pull (fast-forward).
+    - Existing clone with mismatched origin → :class:`ProjectCloneError`.
+    - Existing path that is not a git repo → :class:`ProjectCloneError`.
+
+    Returns the local clone path on success.
+    """
+    if not repo_name:
+        raise ProjectCloneError("repo_name is empty")
+    if not ssh_url:
+        raise ProjectCloneError("ssh_url is empty")
+
+    rewritten = rewrite_to_alias(ssh_url, alias)
+    dest = project_clone_path(repo_name)
+    ensure_projects_dir()
+
+    if not os.path.exists(dest):
+        try:
+            kw = {}
+            if branch:
+                kw["branch"] = branch
+            Repo.clone_from(rewritten, dest, **kw)
+            return dest
+        except GitCommandError as exc:
+            raise ProjectCloneError("git clone {} → {} failed: {}".format(rewritten, dest, exc))
+
+    if not is_clone_of(dest, rewritten):
+        raise ProjectCloneError("{} exists but origin does not match {}".format(dest, rewritten))
+
+    try:
+        repo = Repo(dest)
+        repo.remote("origin").pull()
+        return dest
+    except GitCommandError as exc:
+        raise ProjectCloneError("git pull at {} failed: {}".format(dest, exc))
+
+
+def list_local_projects():
+    """Return repo names with a ``.git`` directory under ``projects_dir``."""
+    pdir = projects_dir()
+    if not os.path.isdir(pdir):
+        return []
+    out = []
+    for name in sorted(os.listdir(pdir)):
+        candidate = os.path.join(pdir, name)
+        if os.path.isdir(os.path.join(candidate, ".git")):
+            out.append(name)
+    return out
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/repo_picker.py
+++ b/pychron/cloud/repo_picker.py
@@ -1,0 +1,116 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Repo picker model for Pychron Cloud "Open Project" (M7 P4).
+
+Headless model: fetches the lab's repo list from pychronAPI, filters
+client-side, and clones the chosen repo through the workstation SSH
+alias. Wired to a Traits view in a follow-up; the logic is kept here so
+it can be unit-tested without a UI.
+"""
+
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+
+from pychron.cloud.api_client import list_repositories
+from pychron.cloud.paths import pychron_dir
+from pychron.cloud.projects import clone_or_pull
+from pychron.cloud.workstation_setup import load_registration
+
+logger = logging.getLogger(__name__)
+
+
+def _last_repo_cache_path():
+    return os.path.join(pychron_dir(), "last_repo.json")
+
+
+def load_last_repo():
+    """Return the most recently opened repo identifier, or empty string."""
+    path = _last_repo_cache_path()
+    if not os.path.isfile(path):
+        return ""
+    try:
+        with open(path, "r") as f:
+            return json.load(f).get("repository_identifier", "") or ""
+    except (ValueError, OSError):
+        return ""
+
+
+def save_last_repo(repository_identifier):
+    """Persist the repo identifier so the picker can pre-select it."""
+    if not repository_identifier:
+        return
+    os.makedirs(pychron_dir(), exist_ok=True)
+    path = _last_repo_cache_path()
+    with open(path, "w") as f:
+        json.dump({"repository_identifier": repository_identifier}, f)
+    if os.name == "posix":
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+
+class RepoPicker(object):
+    """Model for the "Open Project" picker.
+
+    The picker is intentionally stateless beyond what is needed for one
+    open: a fresh instance per "Open Project" invocation is the expected
+    usage pattern.
+    """
+
+    def __init__(self, api_base_url, api_token, lab_name, alias=None):
+        self.api_base_url = api_base_url
+        self.api_token = api_token
+        self.lab_name = lab_name
+        self._alias = alias
+
+    @property
+    def alias(self):
+        if self._alias:
+            return self._alias
+        # Fall back to the stored registration so the caller doesn't have
+        # to thread the alias through the prefs pane.
+        reg = load_registration() or {}
+        return (reg.get("ssh_host_alias") or {}).get("alias", "")
+
+    def fetch(self):
+        """Return the list of :class:`Repository` for the configured lab."""
+        return list_repositories(self.api_base_url, self.api_token, self.lab_name)
+
+    def open(self, repository):
+        """Clone or pull ``repository`` into ``~/Pychron/projects/<name>``.
+
+        ``repository`` may be a :class:`Repository` or a plain dict with
+        ``repository_identifier`` and ``ssh_url`` keys.
+        """
+        if hasattr(repository, "repository_identifier"):
+            name = repository.repository_identifier
+            ssh_url = repository.ssh_url
+            branch = repository.default_branch
+        else:
+            name = repository.get("repository_identifier", "")
+            ssh_url = repository.get("ssh_url", "")
+            branch = repository.get("default_branch", "main")
+
+        path = clone_or_pull(name, ssh_url, self.alias, branch=branch)
+        save_last_repo(name)
+        return path
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/ssh_config.py
+++ b/pychron/cloud/ssh_config.py
@@ -1,0 +1,199 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""SSH config + known_hosts writers for Pychron Cloud (M7 P2).
+
+Two file mutations:
+
+- Append a single ``known_hosts_line`` to a Pychron-scoped known_hosts
+  file under ``~/.pychron/known_hosts`` so we never edit the user's
+  global ``~/.ssh/known_hosts``.
+- Insert / replace a block-managed ``Host pychron-<lab>`` stanza in
+  ``~/.ssh/config``. The block is delimited by sentinel comments so we
+  can rewrite it idempotently without touching anything else in the
+  user's config.
+"""
+
+from __future__ import absolute_import
+
+import os
+import re
+
+from pychron.cloud.paths import (
+    ensure_pychron_dirs,
+    known_hosts_path,
+    ssh_config_path,
+)
+
+
+BEGIN_MARKER = "# BEGIN pychron-cloud:{alias}"
+END_MARKER = "# END pychron-cloud:{alias}"
+
+
+def append_known_hosts_line(line, path=None):
+    """Append ``line`` to the Pychron known_hosts file if absent.
+
+    Returns True if the file was modified, False if the line was already
+    present (exact match, ignoring trailing whitespace).
+    """
+    if not line:
+        return False
+    line = line.strip()
+    ensure_pychron_dirs()
+    path = path or known_hosts_path()
+
+    existing = ""
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            existing = f.read()
+    for existing_line in existing.splitlines():
+        if existing_line.strip() == line:
+            return False
+
+    with open(path, "a") as f:
+        if existing and not existing.endswith("\n"):
+            f.write("\n")
+        f.write(line + "\n")
+    if os.name == "posix":
+        os.chmod(path, 0o600)
+    return True
+
+
+def render_host_block(alias, real_host, port, identity_file, known_hosts_file):
+    """Render the ``Host <alias>`` block (without sentinels)."""
+    return (
+        "Host {alias}\n"
+        "    HostName {real_host}\n"
+        "    Port {port}\n"
+        "    User git\n"
+        "    IdentityFile {identity_file}\n"
+        "    IdentitiesOnly yes\n"
+        "    UserKnownHostsFile {known_hosts_file}\n"
+    ).format(
+        alias=alias,
+        real_host=real_host,
+        port=port,
+        identity_file=identity_file,
+        known_hosts_file=known_hosts_file,
+    )
+
+
+def _block_pattern(alias):
+    begin = re.escape(BEGIN_MARKER.format(alias=alias))
+    end = re.escape(END_MARKER.format(alias=alias))
+    # Non-greedy across newlines including the trailing newline of the
+    # END marker so a clean rewrite leaves no orphan blank lines.
+    return re.compile(r"(?:^|\n)" + begin + r"\n.*?\n" + end + r"\n?", re.DOTALL)
+
+
+def upsert_ssh_config_block(
+    alias,
+    real_host,
+    port,
+    identity_file,
+    known_hosts_file,
+    path=None,
+):
+    """Insert or replace the Pychron Cloud block in ``~/.ssh/config``.
+
+    Idempotent: if an existing block for ``alias`` matches the rendered
+    content exactly, the file is not rewritten and ``False`` is
+    returned. Returns ``True`` when the file is modified.
+    """
+    path = path or ssh_config_path()
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+        if os.name == "posix":
+            try:
+                os.chmod(parent, 0o700)
+            except OSError:
+                pass
+
+    body = render_host_block(
+        alias=alias,
+        real_host=real_host,
+        port=port,
+        identity_file=identity_file,
+        known_hosts_file=known_hosts_file,
+    )
+    new_block = "{begin}\n{body}{end}\n".format(
+        begin=BEGIN_MARKER.format(alias=alias),
+        body=body,
+        end=END_MARKER.format(alias=alias),
+    )
+
+    existing = ""
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            existing = f.read()
+
+    pattern = _block_pattern(alias)
+    match = pattern.search(existing)
+
+    if match:
+        current = match.group(0).lstrip("\n")
+        if current.rstrip("\n") == new_block.rstrip("\n"):
+            return False
+        # Replace in place, preserving the leading newline (if any) so
+        # we do not collapse adjacent unrelated blocks.
+        replaced = (
+            existing[: match.start()]
+            + ("\n" if existing[: match.start()].endswith("\n") or match.start() == 0 else "\n")
+            + new_block
+            + existing[match.end() :]
+        )
+        # Normalize: avoid leading newline on a fresh file.
+        if match.start() == 0 and replaced.startswith("\n"):
+            replaced = replaced.lstrip("\n")
+        new_content = replaced
+    else:
+        sep = ""
+        if existing and not existing.endswith("\n"):
+            sep = "\n"
+        elif existing and not existing.endswith("\n\n"):
+            sep = "\n"
+        new_content = existing + sep + new_block
+
+    with open(path, "w") as f:
+        f.write(new_content)
+    if os.name == "posix":
+        os.chmod(path, 0o600)
+    return True
+
+
+def remove_ssh_config_block(alias, path=None):
+    """Remove the block for ``alias`` from ``~/.ssh/config``.
+
+    Returns ``True`` if a block was removed, ``False`` otherwise.
+    """
+    path = path or ssh_config_path()
+    if not os.path.isfile(path):
+        return False
+    with open(path, "r") as f:
+        existing = f.read()
+    pattern = _block_pattern(alias)
+    new_content, n = pattern.subn("", existing)
+    if n == 0:
+        return False
+    new_content = new_content.lstrip("\n")
+    with open(path, "w") as f:
+        f.write(new_content)
+    if os.name == "posix":
+        os.chmod(path, 0o600)
+    return True
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/ssh_keygen.py
+++ b/pychron/cloud/ssh_keygen.py
@@ -1,0 +1,105 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""ed25519 keypair generation for Pychron Cloud workstations (M7 P2).
+
+Generates an OpenSSH-format private key + a single-line public key.
+Idempotent — :func:`ensure_keypair` returns the existing pair if both
+files exist; only generates on a miss.
+"""
+
+from __future__ import absolute_import
+
+import os
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from pychron.cloud.paths import (
+    ensure_pychron_dirs,
+    host_slug,
+    key_path,
+    public_key_path,
+)
+
+
+def _comment(host):
+    return "pychron-{}".format(host)
+
+
+def generate_keypair(host=None):
+    """Generate a fresh ed25519 keypair, overwriting any existing files.
+
+    Returns ``(private_path, public_path)``.
+    """
+    ensure_pychron_dirs()
+    host = host or host_slug()
+    priv_path = key_path(host)
+    pub_path = public_key_path(host)
+
+    private_key = Ed25519PrivateKey.generate()
+    priv_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )
+
+    # Write private key first with 0600 so it is never briefly world-
+    # readable.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    mode = 0o600
+    fd = os.open(priv_path, flags, mode)
+    try:
+        os.write(fd, priv_bytes)
+    finally:
+        os.close(fd)
+    if os.name == "posix":
+        os.chmod(priv_path, 0o600)
+
+    pub_line = pub_bytes.decode("ascii").strip() + " " + _comment(host) + "\n"
+    with open(pub_path, "w") as f:
+        f.write(pub_line)
+    if os.name == "posix":
+        os.chmod(pub_path, 0o644)
+
+    return priv_path, pub_path
+
+
+def ensure_keypair(host=None):
+    """Return ``(private_path, public_path)``, generating if either is missing.
+
+    Both files must exist for the pair to be considered present — a stray
+    ``.pub`` without a private key is treated as missing and forces a
+    regeneration.
+    """
+    host = host or host_slug()
+    priv_path = key_path(host)
+    pub_path = public_key_path(host)
+    if os.path.isfile(priv_path) and os.path.isfile(pub_path):
+        return priv_path, pub_path
+    return generate_keypair(host)
+
+
+def read_public_key(host=None):
+    pub_path = public_key_path(host)
+    with open(pub_path, "r") as f:
+        return f.read().strip()
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/tasks/__init__.py
+++ b/pychron/cloud/tasks/__init__.py
@@ -1,0 +1,15 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================

--- a/pychron/cloud/tasks/cloud_plugin.py
+++ b/pychron/cloud/tasks/cloud_plugin.py
@@ -1,0 +1,35 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Envisage plugin that contributes the Pychron Cloud preferences pane."""
+
+from __future__ import absolute_import
+
+from pychron.cloud.tasks.preferences import CloudPreferencesPane
+from pychron.envisage.tasks.base_task_plugin import BaseTaskPlugin
+
+
+class CloudPlugin(BaseTaskPlugin):
+    id = "pychron.cloud.plugin"
+    name = "PychronCloud"
+
+    def _preferences_panes_default(self):
+        return [CloudPreferencesPane]
+
+    def _preferences_default(self):
+        return self._preferences_factory("cloud")
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/tasks/preferences.py
+++ b/pychron/cloud/tasks/preferences.py
@@ -1,0 +1,289 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Preferences pane for the Pychron Cloud (pychronAPI) integration (M7 P1).
+
+Adds a "Pychron Cloud" pane with:
+
+- ``enable_pychron_cloud`` feature flag (Bool)
+- ``api_base_url`` (Str, persisted to .cfg)
+- ``lab_name`` (Str, persisted to .cfg)
+- ``api_token`` (Password, *not* persisted to .cfg — kept in OS keyring)
+- A "Test Connection" button that calls ``/api/v1/forgejo/whoami`` and
+  surfaces the returned scopes/lab so the operator can confirm the token
+  can actually register a workstation SSH key (P2).
+"""
+
+from __future__ import absolute_import
+
+import logging
+
+from envisage.ui.tasks.preferences_pane import PreferencesPane
+from traits.api import Bool, Button, Password, Str
+from traitsui.api import Color, Group, HGroup, Item, VGroup, View
+
+from pychron.cloud.api_client import (
+    CloudAPIError,
+    CloudAuthError,
+    CloudNetworkError,
+    whoami,
+)
+from pychron.cloud.keyring_store import (
+    delete_token,
+    get_token,
+    set_token,
+)
+from pychron.cloud.workstation_setup import (
+    WorkstationSetup,
+    WorkstationSetupError,
+    switch_lab as wipe_for_switch_lab,
+)
+from pychron.core.confirmation import confirmation_dialog
+from pychron.core.helpers.color_utils import normalize_color_name
+from pychron.core.ui.custom_label_editor import CustomLabel
+from pychron.envisage.tasks.base_preferences_helper import (
+    BasePreferencesHelper,
+    test_connection_item,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CloudPreferences(BasePreferencesHelper):
+    """Preferences for the pychronAPI workstation onboarding flow."""
+
+    preferences_path = "pychron.cloud"
+
+    enable_pychron_cloud = Bool(False)
+    api_base_url = Str
+    lab_name = Str
+    api_token = Password
+
+    test_connection = Button
+    reonboard_button = Button("Re-onboard workstation")
+    revoke_button = Button("Revoke this workstation")
+    switch_lab_button = Button("Switch lab (destructive)")
+    _remote_status = Str
+    _remote_status_color = Color
+
+    def _remote_status_color_default(self):
+        return normalize_color_name("red")
+
+    def _initialize(self, *args, **kw):
+        super(CloudPreferences, self)._initialize(*args, **kw)
+        self._load_token_from_keyring()
+
+    def _is_preference_trait(self, trait_name):
+        # api_token must never be written to the .cfg — it lives in the OS
+        # keyring. The transient remote-status traits and the lifecycle
+        # buttons also stay out.
+        if trait_name in (
+            "api_token",
+            "_remote_status",
+            "_remote_status_color",
+            "test_connection",
+            "reonboard_button",
+            "revoke_button",
+            "switch_lab_button",
+        ):
+            return False
+        return super(CloudPreferences, self)._is_preference_trait(trait_name)
+
+    def _load_token_from_keyring(self):
+        token = get_token(self.lab_name)
+        if token != self.api_token:
+            self.trait_setq(api_token=token)
+
+    def _lab_name_changed(self, old, new):
+        # Different lab → different keyring slot. Pull whatever is stored
+        # there so the user sees the right token without re-entering it.
+        if old != new:
+            self._load_token_from_keyring()
+
+    def _api_token_changed(self, old, new):
+        if not self.lab_name:
+            # No lab → nowhere to file it. Do not silently drop.
+            self._remote_status = "Set lab_name first"
+            self._remote_status_color = normalize_color_name("red")
+            return
+        if new:
+            set_token(self.lab_name, new)
+        elif old:
+            delete_token(self.lab_name)
+
+    def _test_connection_fired(self):
+        self._remote_status_color = normalize_color_name("red")
+        if not self.api_base_url:
+            self._remote_status = "No URL"
+            return
+        if not self.api_token:
+            self._remote_status = "No token"
+            return
+        try:
+            info = whoami(self.api_base_url, self.api_token)
+        except CloudAuthError:
+            self._remote_status = "401 Unauthorized"
+            return
+        except CloudNetworkError as exc:
+            logger.warning("cloud whoami transport failure: %s", exc)
+            self._remote_status = "Unreachable"
+            return
+        except CloudAPIError as exc:
+            logger.warning("cloud whoami failure: %s", exc)
+            self._remote_status = "Invalid"
+            return
+
+        if self.lab_name and info.lab and info.lab != self.lab_name:
+            self._remote_status = "Lab mismatch ({})".format(info.lab)
+            return
+        if not info.can_register_ssh_key():
+            self._remote_status = "Missing scope (have: {})".format(",".join(info.scopes) or "none")
+            self._remote_status_color = normalize_color_name("orange")
+            return
+
+        self._remote_status = "OK ({} / {})".format(info.kind or "?", info.lab or "?")
+        self._remote_status_color = normalize_color_name("green")
+
+    # -- P6 buttons ---------------------------------------------------
+
+    def _build_setup(self):
+        return WorkstationSetup(
+            api_base_url=self.api_base_url,
+            api_token=self.api_token,
+            lab_name=self.lab_name,
+        )
+
+    def _reonboard_button_fired(self):
+        self._remote_status_color = normalize_color_name("red")
+        if not (self.api_base_url and self.api_token and self.lab_name):
+            self._remote_status = "Need URL, token, and lab"
+            return
+        try:
+            self._build_setup().reonboard()
+        except CloudAuthError:
+            self._remote_status = "401 Unauthorized — re-enter token"
+            return
+        except (CloudAPIError, WorkstationSetupError) as exc:
+            logger.warning("re-onboard failed: %s", exc)
+            self._remote_status = "Re-onboard failed"
+            return
+        self._remote_status = "Re-onboarded"
+        self._remote_status_color = normalize_color_name("green")
+
+    def _revoke_button_fired(self):
+        self._remote_status_color = normalize_color_name("red")
+        if not confirmation_dialog(
+            "Revoke this workstation? The pychronAPI token and SSH key will "
+            "be deleted on the server, and all local cloud credentials will "
+            "be removed. Per-repo clones under ~/Pychron/projects/ are kept.",
+            title="Revoke workstation",
+        ):
+            return
+        try:
+            self._build_setup().revoke_and_wipe()
+        except CloudAPIError as exc:
+            # revoke_and_wipe wipes locally even when the revoke call
+            # fails; surface the server-side failure but mark the local
+            # state as cleaned up.
+            logger.warning("server revoke failed (local state wiped): %s", exc)
+            self._remote_status = "Local wiped; server revoke failed"
+        else:
+            self._remote_status = "Revoked"
+            self._remote_status_color = normalize_color_name("green")
+        # Clear the keyring slot for this lab so the token is not
+        # silently restored on next pane open.
+        if self.lab_name:
+            delete_token(self.lab_name)
+        self.trait_setq(api_token="")
+
+    def _switch_lab_button_fired(self):
+        self._remote_status_color = normalize_color_name("red")
+        if not confirmation_dialog(
+            "Switching the lab is destructive. The local SSH key, "
+            "~/.pychron state, and ALL clones under ~/Pychron/projects/ "
+            "will be deleted. The keyring token for the current lab will "
+            "also be removed. Continue?",
+            title="Switch lab",
+        ):
+            return
+        # Capture the lab name we are leaving before clearing prefs so we
+        # can target the right keyring slot.
+        old_lab = self.lab_name
+        wipe_for_switch_lab()
+        if old_lab:
+            delete_token(old_lab)
+        self.trait_setq(api_token="", lab_name="", api_base_url="")
+        self._remote_status = "Wiped; configure new lab above"
+        self._remote_status_color = normalize_color_name("orange")
+
+
+class CloudPreferencesPane(PreferencesPane):
+    model_factory = CloudPreferences
+    category = "Pychron Cloud"
+
+    def traits_view(self):
+        creds = VGroup(
+            Item(
+                "enable_pychron_cloud",
+                tooltip="Master feature flag for the pychronAPI workstation "
+                "onboarding flow (M7). When off, no cloud calls are made.",
+                label="Enabled",
+            ),
+            Item(
+                "api_base_url",
+                tooltip="Base URL of the pychronAPI service, e.g. "
+                "https://pychron-api-xyz-uc.a.run.app",
+                resizable=True,
+                label="API Base URL",
+            ),
+            Item(
+                "lab_name",
+                tooltip="Lab name as registered in pychronAPI (matches the "
+                "lab prefix in the API token, e.g. 'nmgrl' from "
+                "pcy_nmgrl_<random>).",
+                label="Lab",
+            ),
+            Item(
+                "api_token",
+                tooltip="API token shaped pcy_<lab>_<random>. Stored in the "
+                "OS keyring, never in the .cfg file. The token must carry "
+                "the workstations:register_ssh_key scope.",
+                resizable=True,
+                label="API Token",
+            ),
+            HGroup(
+                test_connection_item(),
+                CustomLabel(
+                    "_remote_status",
+                    width=240,
+                    color_name="_remote_status_color",
+                ),
+            ),
+            show_border=True,
+            label="Pychron Cloud (pychronAPI)",
+        )
+        lifecycle = VGroup(
+            HGroup(
+                Item("reonboard_button", show_label=False),
+                Item("revoke_button", show_label=False),
+                Item("switch_lab_button", show_label=False),
+            ),
+            show_border=True,
+            label="Workstation Lifecycle",
+        )
+        return View(Group(creds, lifecycle))
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/url_rewrite.py
+++ b/pychron/cloud/url_rewrite.py
@@ -1,0 +1,73 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Rewrite Forgejo SSH URLs onto the workstation's per-lab SSH alias.
+
+The pychronAPI handshake (M7 P2) drops a ``Host pychron-<lab>`` block in
+``~/.ssh/config`` that pins the IdentityFile, port, and known_hosts. To
+push/pull through that block git must clone via ``pychron-<lab>:owner/
+repo.git`` rather than ``git@forgejo.example:owner/repo.git`` — same
+remote, different transport keying.
+
+This module's only job is the URL surgery. Two input forms are
+supported:
+
+- SCP-style: ``[user@]host:path`` → ``alias:path``
+- ssh:// URI: ``ssh://[user@]host[:port]/path`` → ``alias:path``
+
+Anything else (already alias-formed, https://, file://, ...) is
+returned unchanged.
+"""
+
+from __future__ import absolute_import
+
+import re
+
+_SCP_RE = re.compile(r"^(?:(?P<user>[^@]+)@)?(?P<host>[^:/\s]+):(?P<path>[^:].*)$")
+_SSH_RE = re.compile(r"^ssh://(?:(?P<user>[^@]+)@)?(?P<host>[^:/\s]+)(?::\d+)?/(?P<path>.+)$")
+
+
+def rewrite_to_alias(ssh_url, alias):
+    """Return ``alias:<path>`` for a Forgejo-style SSH URL, else input.
+
+    ``alias`` is the value from ``Host pychron-<lab>`` in ``~/.ssh/config``
+    (e.g. ``pychron-nmgrl``). Empty alias is treated as a no-op so callers
+    can pass through unconditionally.
+    """
+    if not ssh_url or not alias:
+        return ssh_url
+
+    # Already alias-formed (no host segment, just "<alias>:path"). Treat
+    # any token whose left side matches the alias as a pass-through.
+    if ssh_url.startswith("{}:".format(alias)):
+        return ssh_url
+
+    m = _SSH_RE.match(ssh_url)
+    if m:
+        return "{}:{}".format(alias, m.group("path"))
+
+    # SCP form requires a ":" before any "/" — anything with "://" is a
+    # URI scheme (https://, file://, ...) and must pass through unchanged.
+    if "://" in ssh_url:
+        return ssh_url
+
+    m = _SCP_RE.match(ssh_url)
+    if m:
+        return "{}:{}".format(alias, m.group("path"))
+
+    return ssh_url
+
+
+# ============= EOF =============================================

--- a/pychron/cloud/workstation_setup.py
+++ b/pychron/cloud/workstation_setup.py
@@ -1,0 +1,301 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Workstation onboarding orchestrator (M7 P2).
+
+End-to-end flow:
+
+1. Ensure ``~/.pychron/keys/pychron_<host>`` keypair exists (generate if
+   missing).
+2. POST the public key to pychronAPI
+   ``/api/v1/forgejo/workstations/ssh-keys``.
+3. Persist the response to ``~/.pychron/registration.json`` for future
+   runs.
+4. Append the returned ``known_hosts_line`` to ``~/.pychron/known_hosts``.
+5. Insert / replace the ``Host pychron-<lab>`` block in ``~/.ssh/config``.
+
+Idempotency rules:
+
+- Re-running with a valid local keypair AND a stored registration is a
+  no-op for the local filesystem (the SSH config block is rewritten only
+  if it has drifted).
+- If the server returns
+  :class:`pychron.cloud.api_client.CloudFingerprintRejected`, the local
+  keypair is rotated (regenerated) and the call retried once. This
+  handles the case where the server-side row was wiped (M3 reaper) but
+  the local key persists.
+- Any other server / transport error aborts the run and surfaces a typed
+  exception to the caller.
+"""
+
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+
+from pychron.cloud.api_client import (
+    CloudAPIError,
+    CloudFingerprintRejected,
+    register_ssh_key,
+    revoke_workstation_token,
+)
+from pychron.cloud.paths import (
+    ensure_pychron_dirs,
+    host_slug,
+    known_hosts_path,
+    project_clone_path,
+    projects_dir,
+    public_key_path,
+    registration_path,
+    key_path as default_key_path,
+)
+from pychron.cloud.ssh_config import (
+    append_known_hosts_line,
+    remove_ssh_config_block,
+    upsert_ssh_config_block,
+)
+from pychron.cloud.ssh_keygen import (
+    ensure_keypair,
+    generate_keypair,
+    read_public_key,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class WorkstationSetupError(Exception):
+    """Raised when onboarding cannot complete."""
+
+
+class WorkstationSetup(object):
+    """Onboard the current workstation against a pychronAPI lab.
+
+    The constructor takes the bound preference values directly so this
+    class is decoupled from the Traits / Envisage stack and unit-testable
+    without a running application.
+    """
+
+    def __init__(self, api_base_url, api_token, lab_name, host=None):
+        self.api_base_url = api_base_url
+        self.api_token = api_token
+        self.lab_name = lab_name
+        self.host = host or host_slug()
+
+    # -- public entry --------------------------------------------------
+
+    def run(self):
+        """Run the full onboarding sequence. Returns the registration dict."""
+        if not self.api_base_url:
+            raise WorkstationSetupError("api_base_url is empty")
+        if not self.api_token:
+            raise WorkstationSetupError("api_token is empty")
+        if not self.lab_name:
+            raise WorkstationSetupError("lab_name is empty")
+
+        ensure_pychron_dirs()
+        ensure_keypair(self.host)
+        registration = self._register_with_retry()
+        self._persist_registration(registration)
+        self._apply_ssh_config(registration)
+        return registration.raw
+
+    # -- steps ---------------------------------------------------------
+
+    def _register_with_retry(self):
+        public_key = read_public_key(self.host)
+        title = "pychron-{}".format(self.host)
+        try:
+            return register_ssh_key(self.api_base_url, self.api_token, public_key, title=title)
+        except CloudFingerprintRejected as exc:
+            logger.warning("pychronAPI rejected key fingerprint, rotating local key: %s", exc)
+            generate_keypair(self.host)
+            public_key = read_public_key(self.host)
+            return register_ssh_key(self.api_base_url, self.api_token, public_key, title=title)
+
+    def _persist_registration(self, registration):
+        path = registration_path()
+        with open(path, "w") as f:
+            json.dump(registration.raw, f, indent=2, sort_keys=True)
+        if os.name == "posix":
+            os.chmod(path, 0o600)
+
+    def _apply_ssh_config(self, registration):
+        if registration.known_hosts_line:
+            append_known_hosts_line(registration.known_hosts_line)
+        if registration.alias:
+            from pychron.cloud.paths import known_hosts_path
+
+            upsert_ssh_config_block(
+                alias=registration.alias,
+                real_host=registration.real_host,
+                port=registration.port or 22,
+                identity_file=default_key_path(self.host),
+                known_hosts_file=known_hosts_path(),
+            )
+
+    # -- P6: re-onboard / revoke ---------------------------------------
+
+    def reonboard(self):
+        """Force-rotate the local keypair and re-register with pychronAPI.
+
+        Server is expected to replace the prior row keyed by token (per
+        plan / M3 server contract). The local SSH config block is
+        rewritten to match whatever alias the server returns — handles
+        the case where the lab's host alias changed too.
+        """
+        if not (self.api_base_url and self.api_token and self.lab_name):
+            raise WorkstationSetupError("reonboard requires api_base_url, api_token, and lab_name")
+        ensure_pychron_dirs()
+        # Remove the previous SSH config block before regenerating so a
+        # mid-flight failure leaves no stale alias pointing at a dead key.
+        prior_alias = _alias_from_registration(load_registration())
+        if prior_alias:
+            remove_ssh_config_block(prior_alias)
+
+        generate_keypair(self.host)
+        registration = self._register_with_retry()
+        self._persist_registration(registration)
+        self._apply_ssh_config(registration)
+        return registration.raw
+
+    def revoke_and_wipe(self):
+        """Revoke the server-side token then erase all local artifacts.
+
+        Idempotent. A revoke failure is surfaced to the caller; local
+        wipe still runs after a transport-level failure to avoid leaving
+        the workstation half-onboarded.
+        """
+        revoke_error = None
+        try:
+            revoke_workstation_token(self.api_base_url, self.api_token)
+        except CloudAPIError as exc:
+            logger.warning("token revoke failed: %s", exc)
+            revoke_error = exc
+
+        wipe_local_state(self.host, registered_alias=None)
+
+        if revoke_error is not None:
+            raise revoke_error
+
+    # -- helpers -------------------------------------------------------
+
+    def public_key_path(self):
+        return public_key_path(self.host)
+
+
+def _alias_from_registration(reg):
+    if not reg:
+        return ""
+    alias = (reg.get("ssh_host_alias") or {}).get("alias", "")
+    return alias or ""
+
+
+def wipe_local_state(host=None, registered_alias=None, wipe_projects=False):
+    """Remove every artifact written by P2 (and optionally P4 clones).
+
+    Used by ``revoke_and_wipe`` and by "Switch lab" (with
+    ``wipe_projects=True``). The keyring token is *not* removed here —
+    that lives next to the prefs / lab name and is the responsibility
+    of the caller (the prefs pane) which knows the lab name.
+
+    Parameters:
+        host: hostname slug for the local key file. Defaults to the
+            current machine.
+        registered_alias: explicit alias to scrub from ``~/.ssh/config``.
+            If absent, falls back to the alias in
+            ``~/.pychron/registration.json``.
+        wipe_projects: also delete ``~/Pychron/projects/`` (destructive
+            "Switch lab" path).
+    """
+    host = host or host_slug()
+    alias = registered_alias or _alias_from_registration(load_registration())
+
+    # Local keypair.
+    for path in (default_key_path(host), public_key_path(host)):
+        if os.path.isfile(path):
+            try:
+                os.remove(path)
+            except OSError as exc:
+                logger.warning("could not remove %s: %s", path, exc)
+
+    # SSH config block.
+    if alias:
+        try:
+            remove_ssh_config_block(alias)
+        except OSError as exc:
+            logger.warning("could not edit ssh config: %s", exc)
+
+    # Pychron-scoped known_hosts: discard wholesale — it is only ever
+    # populated by P2 and we cannot safely pick one line out of it
+    # without the registration metadata (which we may have just deleted).
+    if os.path.isfile(known_hosts_path()):
+        try:
+            os.remove(known_hosts_path())
+        except OSError as exc:
+            logger.warning("could not remove %s: %s", known_hosts_path(), exc)
+
+    # Persisted registration + last-repo cache.
+    if os.path.isfile(registration_path()):
+        try:
+            os.remove(registration_path())
+        except OSError as exc:
+            logger.warning("could not remove %s: %s", registration_path(), exc)
+
+    last_repo = os.path.join(os.path.dirname(registration_path()), "last_repo.json")
+    if os.path.isfile(last_repo):
+        try:
+            os.remove(last_repo)
+        except OSError as exc:
+            logger.warning("could not remove %s: %s", last_repo, exc)
+
+    if wipe_projects and os.path.isdir(projects_dir()):
+        import shutil
+
+        try:
+            shutil.rmtree(projects_dir())
+        except OSError as exc:
+            logger.warning("could not wipe %s: %s", projects_dir(), exc)
+
+
+def switch_lab(host=None):
+    """Destructive "Switch lab" wipe per plan P6.
+
+    Removes the workstation keypair, ssh config block, known_hosts,
+    persisted registration, last-repo cache, AND every per-repo clone
+    under ``~/Pychron/projects/``. The caller is responsible for:
+
+    1. Confirming the destructive intent with the user.
+    2. Removing the keyring token entry for the *old* lab.
+    3. Re-running the P1 → P2 → P3 sequence against the new lab.
+    """
+    wipe_local_state(host=host, wipe_projects=True)
+
+
+def load_registration():
+    """Return the persisted registration dict, or ``None`` if absent / unreadable."""
+    path = registration_path()
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (ValueError, OSError) as exc:
+        logger.warning("could not read %s: %s", path, exc)
+        return None
+
+
+# ============= EOF =============================================

--- a/pychron/envisage/pychron_run.py
+++ b/pychron/envisage/pychron_run.py
@@ -48,6 +48,7 @@ PACKAGE_DICT = dict(
     GitLabPlugin="pychron.git.tasks.gitlab_plugin",
     GitHubPlugin="pychron.git.tasks.github_plugin",
     BridgePlugin="pychron.git.tasks.bridge_plugin",
+    CloudPlugin="pychron.cloud.tasks.cloud_plugin",
     LocalGitPlugin="pychron.git.tasks.local_plugin",
     PipelinePlugin="pychron.pipeline.tasks.plugin",
     SparrowPlugin="pychron.sparrow.tasks.plugin",

--- a/pychron/git/hosts/bridge.py
+++ b/pychron/git/hosts/bridge.py
@@ -18,6 +18,14 @@
 Implements the IGitHost interface against the Pychron Forgejo Bridge so
 the existing add_repository / clone / make_url orchestration can route
 through the bridge with no changes to its callers.
+
+DEPRECATED (M7): superseded by direct pychronAPI integration in
+``pychron.cloud`` (workstation onboarding, SSH key registration, repo
+discovery). This module is kept for the M7 rollout overlap so existing
+NMGRL workstations continue to function while ``enable_pychron_cloud``
+is opt-in. Slated for removal after P5 (repo register / migration) ships
+and dogfooding on NMGRL passes — see
+``docs/architecture/forgejo-cloud-onboarding.md``. Do not extend.
 """
 
 from __future__ import absolute_import

--- a/pychron/git/tasks/bridge_plugin.py
+++ b/pychron/git/tasks/bridge_plugin.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+"""Bridge plugin.
+
+DEPRECATED (M7): superseded by ``pychron.cloud.tasks.cloud_plugin``.
+Retained for rollout overlap; remove after P5 dogfood passes.
+"""
+
 from __future__ import absolute_import
 
 from pychron.git.hosts.bridge import BridgeService

--- a/pychron/git/tasks/bridge_preferences.py
+++ b/pychron/git/tasks/bridge_preferences.py
@@ -14,6 +14,13 @@
 # limitations under the License.
 # ===============================================================================
 
+"""Bridge preferences pane.
+
+DEPRECATED (M7): superseded by
+``pychron.cloud.tasks.preferences.CloudPreferencesPane``. Retained for
+rollout overlap; remove after P5 dogfood passes.
+"""
+
 import requests
 from envisage.ui.tasks.preferences_pane import PreferencesPane
 from traits.api import Bool, Button, Password, Str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "envisage>=7.0.4,<8",
     "gitpython>=3.1.45,<4",
     "jinja2>=3.1.6,<4",
+    "keyring>=25.0,<26",
     "lxml>=6.0.4,<7",
     "matplotlib>=3.10.8,<4",
     "numpy>=2.3.4,<3",

--- a/test/cloud/__init__.py
+++ b/test/cloud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the pychron.cloud (M7 P1) package."""

--- a/test/cloud/test_api_client.py
+++ b/test/cloud/test_api_client.py
@@ -1,0 +1,83 @@
+"""Unit tests for pychron.cloud.api_client."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from pychron.cloud import api_client
+
+
+def _resp(status_code=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = text
+    if json_body is None:
+        r.json.side_effect = ValueError("not json")
+    else:
+        r.json.return_value = json_body
+    return r
+
+
+class TestWhoAmI(unittest.TestCase):
+    def test_success_parses_payload(self):
+        body = {
+            "kind": "user_token",
+            "scopes": ["workstations:register_ssh_key"],
+            "lab": "nmgrl",
+        }
+        with patch.object(api_client.requests, "get", return_value=_resp(200, body)):
+            info = api_client.whoami("https://api.example", "pcy_nmgrl_x")
+        self.assertEqual(info.kind, "user_token")
+        self.assertEqual(info.lab, "nmgrl")
+        self.assertTrue(info.can_register_ssh_key())
+
+    def test_success_strips_trailing_slash(self):
+        body = {"kind": "user_token", "scopes": [], "lab": "nmgrl"}
+        with patch.object(api_client.requests, "get", return_value=_resp(200, body)) as g:
+            api_client.whoami("https://api.example/", "pcy_nmgrl_x")
+        called_url = g.call_args[0][0]
+        self.assertEqual(called_url, "https://api.example/api/v1/forgejo/whoami")
+
+    def test_401_raises_auth_error(self):
+        with patch.object(api_client.requests, "get", return_value=_resp(401, text="nope")):
+            with self.assertRaises(api_client.CloudAuthError):
+                api_client.whoami("https://api.example", "pcy_nmgrl_x")
+
+    def test_403_raises_api_error_not_auth(self):
+        with patch.object(
+            api_client.requests, "get", return_value=_resp(403, {"detail": "forbidden"})
+        ):
+            with self.assertRaises(api_client.CloudAPIError) as cm:
+                api_client.whoami("https://api.example", "pcy_nmgrl_x")
+            self.assertNotIsInstance(cm.exception, api_client.CloudAuthError)
+
+    def test_transport_error_raises_network_error(self):
+        with patch.object(
+            api_client.requests,
+            "get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            with self.assertRaises(api_client.CloudNetworkError):
+                api_client.whoami("https://api.example", "pcy_nmgrl_x")
+
+    def test_non_json_body_raises_network_error(self):
+        with patch.object(api_client.requests, "get", return_value=_resp(200, None)):
+            with self.assertRaises(api_client.CloudNetworkError):
+                api_client.whoami("https://api.example", "pcy_nmgrl_x")
+
+    def test_empty_token_raises_auth_error(self):
+        with self.assertRaises(api_client.CloudAuthError):
+            api_client.whoami("https://api.example", "")
+
+    def test_empty_url_raises_api_error(self):
+        with self.assertRaises(api_client.CloudAPIError):
+            api_client.whoami("", "pcy_nmgrl_x")
+
+    def test_can_register_ssh_key_false_when_scope_missing(self):
+        info = api_client.WhoAmI(kind="user_token", scopes=["other"], lab="nmgrl", raw={})
+        self.assertFalse(info.can_register_ssh_key())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_keyring_store.py
+++ b/test/cloud/test_keyring_store.py
@@ -1,0 +1,56 @@
+"""Unit tests for pychron.cloud.keyring_store."""
+
+import unittest
+from unittest.mock import patch
+
+from keyring.errors import KeyringError, PasswordDeleteError
+
+from pychron.cloud import keyring_store
+
+
+class TestKeyringStore(unittest.TestCase):
+    def test_get_token_returns_stored(self):
+        with patch.object(keyring_store.keyring, "get_password", return_value="pcy_lab_xyz") as gp:
+            self.assertEqual(keyring_store.get_token("nmgrl"), "pcy_lab_xyz")
+            gp.assert_called_once_with("pychron.cloud", "nmgrl")
+
+    def test_get_token_empty_lab_uses_default_account(self):
+        with patch.object(keyring_store.keyring, "get_password", return_value=None) as gp:
+            self.assertEqual(keyring_store.get_token(""), "")
+            gp.assert_called_once_with("pychron.cloud", "default")
+
+    def test_get_token_keyring_error_returns_empty(self):
+        with patch.object(keyring_store.keyring, "get_password", side_effect=KeyringError("nope")):
+            self.assertEqual(keyring_store.get_token("nmgrl"), "")
+
+    def test_set_token_writes(self):
+        with patch.object(keyring_store.keyring, "set_password") as sp:
+            self.assertTrue(keyring_store.set_token("nmgrl", "pcy_lab_xyz"))
+            sp.assert_called_once_with("pychron.cloud", "nmgrl", "pcy_lab_xyz")
+
+    def test_set_token_empty_is_noop(self):
+        with patch.object(keyring_store.keyring, "set_password") as sp:
+            self.assertFalse(keyring_store.set_token("nmgrl", ""))
+            sp.assert_not_called()
+
+    def test_set_token_keyring_error_returns_false(self):
+        with patch.object(keyring_store.keyring, "set_password", side_effect=KeyringError("nope")):
+            self.assertFalse(keyring_store.set_token("nmgrl", "pcy_lab_xyz"))
+
+    def test_delete_token_idempotent_on_missing(self):
+        with patch.object(
+            keyring_store.keyring,
+            "delete_password",
+            side_effect=PasswordDeleteError("not found"),
+        ):
+            # No exception, returns False because nothing deleted.
+            self.assertFalse(keyring_store.delete_token("nmgrl"))
+
+    def test_delete_token_success(self):
+        with patch.object(keyring_store.keyring, "delete_password") as dp:
+            self.assertTrue(keyring_store.delete_token("nmgrl"))
+            dp.assert_called_once_with("pychron.cloud", "nmgrl")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_list_repositories.py
+++ b/test/cloud/test_list_repositories.py
@@ -1,0 +1,91 @@
+"""Tests for pychron.cloud.api_client.list_repositories (P4)."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pychron.cloud import api_client
+
+
+def _resp(status_code=200, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = text
+    if json_body is None:
+        r.json.side_effect = ValueError("not json")
+    else:
+        r.json.return_value = json_body
+    return r
+
+
+class ListRepositoriesTestCase(unittest.TestCase):
+    def test_success_with_envelope(self):
+        body = {
+            "repositories": [
+                {
+                    "repository_identifier": "X_001",
+                    "ssh_url": "git@h:lab/X.git",
+                    "https_url": "https://h/lab/X.git",
+                    "default_branch": "main",
+                    "description": "first",
+                },
+                {
+                    "repository_identifier": "Y_002",
+                    "ssh_url": "git@h:lab/Y.git",
+                    "https_url": "https://h/lab/Y.git",
+                },
+            ]
+        }
+        with patch.object(api_client.requests, "get", return_value=_resp(200, body)):
+            repos = api_client.list_repositories("https://api.example", "tok", "nmgrl")
+        self.assertEqual(len(repos), 2)
+        self.assertEqual(repos[0].repository_identifier, "X_001")
+        self.assertEqual(repos[0].description, "first")
+        self.assertEqual(repos[1].default_branch, "main")  # default fill-in
+
+    def test_success_with_bare_list(self):
+        body = [{"repository_identifier": "X_001", "ssh_url": "git@h:l/X.git"}]
+        with patch.object(api_client.requests, "get", return_value=_resp(200, body)):
+            repos = api_client.list_repositories("https://api.example", "tok", "nmgrl")
+        self.assertEqual(len(repos), 1)
+
+    def test_404_returns_empty_list(self):
+        with patch.object(api_client.requests, "get", return_value=_resp(404)):
+            repos = api_client.list_repositories("https://api.example", "tok", "nmgrl")
+        self.assertEqual(repos, [])
+
+    def test_401_raises_auth_error(self):
+        with patch.object(api_client.requests, "get", return_value=_resp(401)):
+            with self.assertRaises(api_client.CloudAuthError):
+                api_client.list_repositories("https://api.example", "tok", "nmgrl")
+
+    def test_403_raises_permission_error(self):
+        with patch.object(api_client.requests, "get", return_value=_resp(403)):
+            with self.assertRaises(api_client.CloudPermissionError):
+                api_client.list_repositories("https://api.example", "tok", "nmgrl")
+
+    def test_5xx_raises_api_error(self):
+        with patch.object(api_client.requests, "get", return_value=_resp(503, text="x")):
+            with self.assertRaises(api_client.CloudAPIError):
+                api_client.list_repositories("https://api.example", "tok", "nmgrl")
+
+    def test_non_list_payload_raises(self):
+        body = {"repositories": "not a list"}
+        with patch.object(api_client.requests, "get", return_value=_resp(200, body)):
+            with self.assertRaises(api_client.CloudNetworkError):
+                api_client.list_repositories("https://api.example", "tok", "nmgrl")
+
+    def test_empty_lab_name_raises(self):
+        with self.assertRaises(api_client.CloudAPIError):
+            api_client.list_repositories("https://api.example", "tok", "")
+
+    def test_url_includes_lab_path(self):
+        with patch.object(
+            api_client.requests, "get", return_value=_resp(200, {"repositories": []})
+        ) as g:
+            api_client.list_repositories("https://api.example", "tok", "nmgrl")
+        called = g.call_args[0][0]
+        self.assertEqual(called, "https://api.example/api/v1/forgejo/labs/nmgrl/repositories")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_p6_lifecycle.py
+++ b/test/cloud/test_p6_lifecycle.py
@@ -1,0 +1,361 @@
+"""Tests for P6: revoke / reonboard / switch_lab + prefs-pane wiring."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from apptools.preferences.api import Preferences, set_default_preferences
+
+from pychron.cloud import api_client, workstation_setup
+from pychron.cloud.tasks.preferences import CloudPreferences
+
+
+def _resp(status_code, json_body=None, text=""):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = text
+    if json_body is None:
+        r.json.side_effect = ValueError("not json")
+    else:
+        r.json.return_value = json_body
+    return r
+
+
+def _registration():
+    return api_client.SSHKeyRegistration(
+        bot_username="bot",
+        fingerprint="SHA256:x",
+        default_metadata_repo="lab/MetaData",
+        ssh_host_alias={
+            "alias": "pychron-nmgrl",
+            "real_host": "forgejo.example",
+            "port": 2222,
+            "known_hosts_line": "[forgejo.example]:2222 ssh-ed25519 AAAA",
+        },
+        raw={
+            "bot_username": "bot",
+            "fingerprint": "SHA256:x",
+            "default_metadata_repo": "lab/MetaData",
+            "ssh_host_alias": {
+                "alias": "pychron-nmgrl",
+                "real_host": "forgejo.example",
+                "port": 2222,
+                "known_hosts_line": "[forgejo.example]:2222 ssh-ed25519 AAAA",
+            },
+        },
+    )
+
+
+class _BaseFSTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(self._rmtree, self.tmp)
+        self._patcher = patch(
+            "pychron.cloud.paths.os.path.expanduser",
+            lambda p: p.replace("~", self.tmp),
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _stub_register(self, **kw):
+        return patch.object(workstation_setup, "register_ssh_key", **kw)
+
+
+# -- api_client.revoke_workstation_token ----------------------------------
+
+
+class RevokeTokenAPITestCase(unittest.TestCase):
+    def test_204_returns_true(self):
+        with patch.object(api_client.requests, "delete", return_value=_resp(204)):
+            self.assertTrue(api_client.revoke_workstation_token("https://api.example", "tok"))
+
+    def test_200_returns_true(self):
+        with patch.object(api_client.requests, "delete", return_value=_resp(200, {"ok": True})):
+            self.assertTrue(api_client.revoke_workstation_token("https://api.example", "tok"))
+
+    def test_401_treated_as_already_revoked(self):
+        with patch.object(api_client.requests, "delete", return_value=_resp(401)):
+            self.assertTrue(api_client.revoke_workstation_token("https://api.example", "tok"))
+
+    def test_404_treated_as_already_revoked(self):
+        with patch.object(api_client.requests, "delete", return_value=_resp(404)):
+            self.assertTrue(api_client.revoke_workstation_token("https://api.example", "tok"))
+
+    def test_500_raises(self):
+        with patch.object(api_client.requests, "delete", return_value=_resp(500, text="boom")):
+            with self.assertRaises(api_client.CloudAPIError):
+                api_client.revoke_workstation_token("https://api.example", "tok")
+
+    def test_transport_error_raises_network_error(self):
+        import requests
+
+        with patch.object(
+            api_client.requests,
+            "delete",
+            side_effect=requests.ConnectionError("dns"),
+        ):
+            with self.assertRaises(api_client.CloudNetworkError):
+                api_client.revoke_workstation_token("https://api.example", "tok")
+
+    def test_empty_token_returns_true_without_call(self):
+        with patch.object(api_client.requests, "delete") as d:
+            self.assertTrue(api_client.revoke_workstation_token("https://api.example", ""))
+            d.assert_not_called()
+
+
+# -- WorkstationSetup.reonboard / revoke_and_wipe / wipe_local_state ------
+
+
+class ReonboardTestCase(_BaseFSTestCase):
+    def test_reonboard_rotates_key(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self._stub_register(return_value=_registration()):
+            ws.run()
+        priv = os.path.join(self.tmp, ".pychron", "keys", "pychron_testhost")
+        with open(priv, "rb") as f:
+            first = f.read()
+
+        with self._stub_register(return_value=_registration()):
+            ws.reonboard()
+
+        with open(priv, "rb") as f:
+            self.assertNotEqual(first, f.read())
+
+    def test_reonboard_replaces_alias_block_when_alias_changes(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self._stub_register(return_value=_registration()):
+            ws.run()
+
+        # New registration uses a different alias.
+        new_reg = api_client.SSHKeyRegistration(
+            bot_username="bot2",
+            fingerprint="SHA256:y",
+            default_metadata_repo="lab/MetaData",
+            ssh_host_alias={
+                "alias": "pychron-newlab",
+                "real_host": "forgejo.example",
+                "port": 2222,
+                "known_hosts_line": "[forgejo.example]:2222 ssh-ed25519 BBBB",
+            },
+            raw={
+                "ssh_host_alias": {
+                    "alias": "pychron-newlab",
+                    "real_host": "forgejo.example",
+                    "port": 2222,
+                    "known_hosts_line": "[forgejo.example]:2222 ssh-ed25519 BBBB",
+                }
+            },
+        )
+        with self._stub_register(return_value=new_reg):
+            ws.reonboard()
+
+        sshc = os.path.join(self.tmp, ".ssh", "config")
+        with open(sshc) as f:
+            body = f.read()
+        self.assertIn("Host pychron-newlab", body)
+        self.assertNotIn("Host pychron-nmgrl", body)
+
+
+class RevokeAndWipeTestCase(_BaseFSTestCase):
+    def _onboard(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self._stub_register(return_value=_registration()):
+            ws.run()
+        return ws
+
+    def _assert_wiped(self):
+        priv = os.path.join(self.tmp, ".pychron", "keys", "pychron_testhost")
+        kh = os.path.join(self.tmp, ".pychron", "known_hosts")
+        reg = os.path.join(self.tmp, ".pychron", "registration.json")
+        sshc = os.path.join(self.tmp, ".ssh", "config")
+        self.assertFalse(os.path.isfile(priv))
+        self.assertFalse(os.path.isfile(kh))
+        self.assertFalse(os.path.isfile(reg))
+        if os.path.isfile(sshc):
+            with open(sshc) as f:
+                self.assertNotIn("pychron-nmgrl", f.read())
+
+    def test_revoke_and_wipe_wipes_local_state_on_success(self):
+        ws = self._onboard()
+        with patch.object(workstation_setup, "revoke_workstation_token", return_value=True):
+            ws.revoke_and_wipe()
+        self._assert_wiped()
+
+    def test_revoke_and_wipe_wipes_local_state_even_when_server_fails(self):
+        ws = self._onboard()
+        with patch.object(
+            workstation_setup,
+            "revoke_workstation_token",
+            side_effect=api_client.CloudNetworkError("boom"),
+        ):
+            with self.assertRaises(api_client.CloudNetworkError):
+                ws.revoke_and_wipe()
+        # Local state still wiped.
+        self._assert_wiped()
+
+
+class SwitchLabTestCase(_BaseFSTestCase):
+    def test_switch_lab_wipes_projects_dir_too(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self._stub_register(return_value=_registration()):
+            ws.run()
+        # Plant a fake project clone.
+        proj = os.path.join(self.tmp, "Pychron", "projects", "X_001")
+        os.makedirs(proj)
+        with open(os.path.join(proj, "marker"), "w") as f:
+            f.write("x")
+
+        workstation_setup.switch_lab(host="testhost")
+
+        self.assertFalse(os.path.isdir(proj))
+        self.assertFalse(os.path.isdir(os.path.join(self.tmp, "Pychron", "projects")))
+
+
+# -- prefs pane button wiring --------------------------------------------
+
+
+class _FakeKeyring(object):
+    def __init__(self):
+        self._store = {}
+
+    def get_password(self, service, account):
+        return self._store.get((service, account))
+
+    def set_password(self, service, account, password):
+        self._store[(service, account)] = password
+
+    def delete_password(self, service, account):
+        try:
+            del self._store[(service, account)]
+        except KeyError:
+            from keyring.errors import PasswordDeleteError
+
+            raise PasswordDeleteError("not found")
+
+
+class PrefsPaneButtonsTestCase(_BaseFSTestCase):
+    def setUp(self):
+        super().setUp()
+        set_default_preferences(Preferences())
+        self.fake_kr = _FakeKeyring()
+        self._kp = patch("pychron.cloud.keyring_store.keyring", self.fake_kr)
+        self._kp.start()
+        self.addCleanup(self._kp.stop)
+
+    def _build(self):
+        h = CloudPreferences(
+            api_base_url="https://api.example",
+            lab_name="nmgrl",
+        )
+        h.api_token = "tok"
+        return h
+
+    def test_reonboard_button_uses_workstation_setup(self):
+        h = self._build()
+        ws = MagicMock()
+        with patch.object(h, "_build_setup", return_value=ws):
+            h._reonboard_button_fired()
+        ws.reonboard.assert_called_once()
+        self.assertEqual(h._remote_status, "Re-onboarded")
+
+    def test_reonboard_button_surfaces_401(self):
+        h = self._build()
+        ws = MagicMock()
+        ws.reonboard.side_effect = api_client.CloudAuthError("nope")
+        with patch.object(h, "_build_setup", return_value=ws):
+            h._reonboard_button_fired()
+        self.assertIn("401", h._remote_status)
+
+    def test_reonboard_button_requires_inputs(self):
+        h = CloudPreferences()
+        h._reonboard_button_fired()
+        self.assertEqual(h._remote_status, "Need URL, token, and lab")
+
+    def test_revoke_button_aborts_when_user_declines(self):
+        h = self._build()
+        ws = MagicMock()
+        with (
+            patch(
+                "pychron.cloud.tasks.preferences.confirmation_dialog",
+                return_value=False,
+            ),
+            patch.object(h, "_build_setup", return_value=ws),
+        ):
+            h._revoke_button_fired()
+        ws.revoke_and_wipe.assert_not_called()
+
+    def test_revoke_button_clears_keyring_and_token(self):
+        h = self._build()
+        # Token already in fake keyring via _api_token_changed.
+        self.assertEqual(self.fake_kr._store.get(("pychron.cloud", "nmgrl")), "tok")
+        ws = MagicMock()
+        with (
+            patch(
+                "pychron.cloud.tasks.preferences.confirmation_dialog",
+                return_value=True,
+            ),
+            patch.object(h, "_build_setup", return_value=ws),
+        ):
+            h._revoke_button_fired()
+        ws.revoke_and_wipe.assert_called_once()
+        self.assertNotIn(("pychron.cloud", "nmgrl"), self.fake_kr._store)
+        self.assertEqual(h.api_token, "")
+
+    def test_switch_lab_button_aborts_when_user_declines(self):
+        h = self._build()
+        with (
+            patch(
+                "pychron.cloud.tasks.preferences.confirmation_dialog",
+                return_value=False,
+            ),
+            patch("pychron.cloud.tasks.preferences.wipe_for_switch_lab") as wipe,
+        ):
+            h._switch_lab_button_fired()
+        wipe.assert_not_called()
+
+    def test_switch_lab_button_wipes_local_state_and_clears_prefs(self):
+        h = self._build()
+        with (
+            patch(
+                "pychron.cloud.tasks.preferences.confirmation_dialog",
+                return_value=True,
+            ),
+            patch("pychron.cloud.tasks.preferences.wipe_for_switch_lab") as wipe,
+        ):
+            h._switch_lab_button_fired()
+        wipe.assert_called_once()
+        self.assertEqual(h.api_token, "")
+        self.assertEqual(h.lab_name, "")
+        self.assertEqual(h.api_base_url, "")
+        self.assertNotIn(("pychron.cloud", "nmgrl"), self.fake_kr._store)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_preferences.py
+++ b/test/cloud/test_preferences.py
@@ -1,0 +1,167 @@
+"""Unit tests for pychron.cloud.tasks.preferences.CloudPreferences.
+
+Covers:
+
+- API token round-trips through the OS keyring helpers (never to .cfg).
+- Switching ``lab_name`` reloads the matching keyring slot.
+- The "Test Connection" button surfaces 401, scope, and lab-mismatch
+  states.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from apptools.preferences.api import Preferences, set_default_preferences
+
+from pychron.cloud import api_client
+from pychron.cloud.tasks.preferences import CloudPreferences
+
+
+class _FakeKeyring(object):
+    """In-memory replacement for :mod:`keyring` so tests do not touch the
+    real OS credential store.
+    """
+
+    def __init__(self):
+        self._store = {}
+
+    def get_password(self, service, account):
+        return self._store.get((service, account))
+
+    def set_password(self, service, account, password):
+        self._store[(service, account)] = password
+
+    def delete_password(self, service, account):
+        try:
+            del self._store[(service, account)]
+        except KeyError:
+            from keyring.errors import PasswordDeleteError
+
+            raise PasswordDeleteError("not found")
+
+
+class CloudPreferencesTestCase(unittest.TestCase):
+    def setUp(self):
+        set_default_preferences(Preferences())
+        self.fake = _FakeKeyring()
+        self._patcher = patch("pychron.cloud.keyring_store.keyring", self.fake)
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def _build(self, **kw):
+        return CloudPreferences(**kw)
+
+    # -- token persistence --------------------------------------------
+
+    def test_api_token_is_not_a_preference_trait(self):
+        helper = self._build()
+        self.assertFalse(helper._is_preference_trait("api_token"))
+
+    def test_api_token_writes_to_keyring(self):
+        helper = self._build(lab_name="nmgrl")
+        helper.api_token = "pcy_nmgrl_xyz"
+        self.assertEqual(self.fake._store.get(("pychron.cloud", "nmgrl")), "pcy_nmgrl_xyz")
+
+    def test_api_token_without_lab_name_is_not_stored(self):
+        helper = self._build()
+        helper.api_token = "pcy_unknown_xyz"
+        self.assertEqual(self.fake._store, {})
+        self.assertEqual(helper._remote_status, "Set lab_name first")
+
+    def test_api_token_clear_deletes_keyring_entry(self):
+        helper = self._build(lab_name="nmgrl")
+        helper.api_token = "pcy_nmgrl_xyz"
+        helper.api_token = ""
+        self.assertNotIn(("pychron.cloud", "nmgrl"), self.fake._store)
+
+    def test_initialize_loads_token_from_keyring(self):
+        # Pre-populate the fake keyring under the lab account.
+        self.fake._store[("pychron.cloud", "nmgrl")] = "pcy_nmgrl_existing"
+        helper = self._build(lab_name="nmgrl")
+        self.assertEqual(helper.api_token, "pcy_nmgrl_existing")
+
+    def test_lab_name_change_reloads_token_for_new_lab(self):
+        self.fake._store[("pychron.cloud", "nmgrl")] = "tok_nmgrl"
+        self.fake._store[("pychron.cloud", "ucla")] = "tok_ucla"
+        helper = self._build(lab_name="nmgrl")
+        self.assertEqual(helper.api_token, "tok_nmgrl")
+        helper.lab_name = "ucla"
+        self.assertEqual(helper.api_token, "tok_ucla")
+
+    # -- test_connection button ---------------------------------------
+
+    def _stub_whoami(self, **kw):
+        return patch.object(
+            __import__("pychron.cloud.tasks.preferences", fromlist=["whoami"]),
+            "whoami",
+            **kw,
+        )
+
+    def test_test_connection_no_url(self):
+        helper = self._build(lab_name="nmgrl")
+        helper.api_token = "pcy_nmgrl_xyz"
+        helper._test_connection_fired()
+        self.assertEqual(helper._remote_status, "No URL")
+
+    def test_test_connection_no_token(self):
+        helper = self._build(lab_name="nmgrl", api_base_url="https://api.example")
+        helper._test_connection_fired()
+        self.assertEqual(helper._remote_status, "No token")
+
+    def test_test_connection_401(self):
+        helper = self._build(lab_name="nmgrl", api_base_url="https://api.example")
+        helper.api_token = "pcy_nmgrl_xyz"
+        with self._stub_whoami(side_effect=api_client.CloudAuthError("401")):
+            helper._test_connection_fired()
+        self.assertEqual(helper._remote_status, "401 Unauthorized")
+
+    def test_test_connection_unreachable(self):
+        helper = self._build(lab_name="nmgrl", api_base_url="https://api.example")
+        helper.api_token = "pcy_nmgrl_xyz"
+        with self._stub_whoami(side_effect=api_client.CloudNetworkError("dns")):
+            helper._test_connection_fired()
+        self.assertEqual(helper._remote_status, "Unreachable")
+
+    def test_test_connection_lab_mismatch(self):
+        helper = self._build(lab_name="nmgrl", api_base_url="https://api.example")
+        helper.api_token = "pcy_nmgrl_xyz"
+        info = api_client.WhoAmI(
+            kind="user_token",
+            scopes=["workstations:register_ssh_key"],
+            lab="ucla",
+            raw={},
+        )
+        with self._stub_whoami(return_value=info):
+            helper._test_connection_fired()
+        self.assertEqual(helper._remote_status, "Lab mismatch (ucla)")
+
+    def test_test_connection_missing_scope(self):
+        helper = self._build(lab_name="nmgrl", api_base_url="https://api.example")
+        helper.api_token = "pcy_nmgrl_xyz"
+        info = api_client.WhoAmI(
+            kind="user_token",
+            scopes=["other:scope"],
+            lab="nmgrl",
+            raw={},
+        )
+        with self._stub_whoami(return_value=info):
+            helper._test_connection_fired()
+        self.assertIn("Missing scope", helper._remote_status)
+        self.assertIn("other:scope", helper._remote_status)
+
+    def test_test_connection_ok(self):
+        helper = self._build(lab_name="nmgrl", api_base_url="https://api.example")
+        helper.api_token = "pcy_nmgrl_xyz"
+        info = api_client.WhoAmI(
+            kind="user_token",
+            scopes=["workstations:register_ssh_key"],
+            lab="nmgrl",
+            raw={},
+        )
+        with self._stub_whoami(return_value=info):
+            helper._test_connection_fired()
+        self.assertTrue(helper._remote_status.startswith("OK"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_projects.py
+++ b/test/cloud/test_projects.py
@@ -1,0 +1,110 @@
+"""Tests for pychron.cloud.projects (clone-or-pull)."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pychron.cloud import projects
+
+
+def _git(cwd, *args):
+    subprocess.check_call(
+        ["git", *args],
+        cwd=cwd,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "T",
+            "GIT_AUTHOR_EMAIL": "t@x",
+            "GIT_COMMITTER_NAME": "T",
+            "GIT_COMMITTER_EMAIL": "t@x",
+        },
+    )
+
+
+class ProjectsTestCase(unittest.TestCase):
+    """Use a real local bare repo as the "remote" so git's transport
+    layer is exercised end-to-end. The alias rewriter is bypassed by
+    passing an empty alias.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(self._rmtree, self.tmp)
+
+        # Build an upstream bare repo with one commit on the configured
+        # default branch ("main") so clone has something to checkout.
+        self.upstream = os.path.join(self.tmp, "upstream.git")
+        os.makedirs(self.upstream)
+        subprocess.check_call(["git", "init", "--bare", "-b", "main", self.upstream])
+
+        seed = os.path.join(self.tmp, "seed")
+        os.makedirs(seed)
+        subprocess.check_call(["git", "init", "-b", "main", seed])
+        with open(os.path.join(seed, "README"), "w") as f:
+            f.write("hi\n")
+        _git(seed, "add", "README")
+        _git(seed, "commit", "-m", "init")
+        _git(seed, "remote", "add", "origin", self.upstream)
+        _git(seed, "push", "origin", "main")
+
+        # Redirect ~ → tmp so projects/<repo> lands in scratch.
+        self._patcher = patch(
+            "pychron.cloud.paths.os.path.expanduser",
+            lambda p: p.replace("~", self.tmp),
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def test_clone_creates_local_repo(self):
+        path = projects.clone_or_pull("X_001", self.upstream, alias="", branch="main")
+        expected = os.path.join(self.tmp, "Pychron", "projects", "X_001")
+        self.assertEqual(path, expected)
+        self.assertTrue(os.path.isfile(os.path.join(expected, "README")))
+
+    def test_pull_after_clone_is_idempotent(self):
+        projects.clone_or_pull("X_001", self.upstream, alias="", branch="main")
+        # Second call should pull (no error) and leave path intact.
+        path = projects.clone_or_pull("X_001", self.upstream, alias="", branch="main")
+        self.assertTrue(os.path.isfile(os.path.join(path, "README")))
+
+    def test_mismatched_origin_aborts(self):
+        projects.clone_or_pull("X_001", self.upstream, alias="", branch="main")
+        # Build a second unrelated bare repo and try to "open" X_001
+        # against it — must refuse.
+        other = os.path.join(self.tmp, "other.git")
+        os.makedirs(other)
+        subprocess.check_call(["git", "init", "--bare", "-b", "main", other])
+        with self.assertRaises(projects.ProjectCloneError):
+            projects.clone_or_pull("X_001", other, alias="", branch="main")
+
+    def test_existing_non_repo_path_aborts(self):
+        dest = os.path.join(self.tmp, "Pychron", "projects", "X_001")
+        os.makedirs(dest)
+        # Empty dir — not a git repo.
+        with self.assertRaises(projects.ProjectCloneError):
+            projects.clone_or_pull("X_001", self.upstream, alias="", branch="main")
+
+    def test_list_local_projects_only_lists_clones(self):
+        projects.clone_or_pull("X_001", self.upstream, alias="", branch="main")
+        # Drop a stray non-repo dir.
+        os.makedirs(os.path.join(self.tmp, "Pychron", "projects", "not_a_repo"), exist_ok=True)
+        self.assertEqual(projects.list_local_projects(), ["X_001"])
+
+    def test_empty_repo_name_raises(self):
+        with self.assertRaises(projects.ProjectCloneError):
+            projects.clone_or_pull("", self.upstream, alias="")
+
+    def test_empty_ssh_url_raises(self):
+        with self.assertRaises(projects.ProjectCloneError):
+            projects.clone_or_pull("X_001", "", alias="")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_repo_picker.py
+++ b/test/cloud/test_repo_picker.py
@@ -1,0 +1,124 @@
+"""Tests for pychron.cloud.repo_picker."""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pychron.cloud import api_client, repo_picker
+
+
+def _git(cwd, *args):
+    subprocess.check_call(
+        ["git", *args],
+        cwd=cwd,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "T",
+            "GIT_AUTHOR_EMAIL": "t@x",
+            "GIT_COMMITTER_NAME": "T",
+            "GIT_COMMITTER_EMAIL": "t@x",
+        },
+    )
+
+
+class RepoPickerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(self._rmtree, self.tmp)
+
+        self._patcher = patch(
+            "pychron.cloud.paths.os.path.expanduser",
+            lambda p: p.replace("~", self.tmp),
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _make_upstream(self):
+        upstream = os.path.join(self.tmp, "upstream.git")
+        os.makedirs(upstream)
+        subprocess.check_call(["git", "init", "--bare", "-b", "main", upstream])
+        seed = os.path.join(self.tmp, "seed")
+        os.makedirs(seed)
+        subprocess.check_call(["git", "init", "-b", "main", seed])
+        with open(os.path.join(seed, "README"), "w") as f:
+            f.write("hi\n")
+        _git(seed, "add", "README")
+        _git(seed, "commit", "-m", "init")
+        _git(seed, "remote", "add", "origin", upstream)
+        _git(seed, "push", "origin", "main")
+        return upstream
+
+    def test_load_last_repo_returns_empty_when_absent(self):
+        self.assertEqual(repo_picker.load_last_repo(), "")
+
+    def test_save_and_load_last_repo_round_trip(self):
+        os.makedirs(os.path.join(self.tmp, ".pychron"), exist_ok=True)
+        repo_picker.save_last_repo("X_001")
+        self.assertEqual(repo_picker.load_last_repo(), "X_001")
+
+    def test_alias_falls_back_to_registration_when_unset(self):
+        # Pre-stage a registration.json with an alias.
+        os.makedirs(os.path.join(self.tmp, ".pychron"), exist_ok=True)
+        reg_path = os.path.join(self.tmp, ".pychron", "registration.json")
+        with open(reg_path, "w") as f:
+            json.dump({"ssh_host_alias": {"alias": "pychron-nmgrl"}}, f)
+        picker = repo_picker.RepoPicker(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+        )
+        self.assertEqual(picker.alias, "pychron-nmgrl")
+
+    def test_fetch_calls_list_repositories(self):
+        picker = repo_picker.RepoPicker(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            alias="pychron-nmgrl",
+        )
+        repos = [api_client.Repository("X_001", "git@h:lab/X.git", "", "main", "")]
+        with patch.object(repo_picker, "list_repositories", return_value=repos) as lr:
+            self.assertEqual(picker.fetch(), repos)
+            lr.assert_called_once_with("https://api.example", "tok", "nmgrl")
+
+    def test_open_clones_and_persists_last_repo(self):
+        upstream = self._make_upstream()
+        picker = repo_picker.RepoPicker(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            alias="",  # alias rewriter no-ops on empty alias
+        )
+        repo = api_client.Repository("X_001", upstream, "", "main", "")
+        path = picker.open(repo)
+        self.assertTrue(os.path.isfile(os.path.join(path, "README")))
+        self.assertEqual(repo_picker.load_last_repo(), "X_001")
+
+    def test_open_accepts_dict_payload(self):
+        upstream = self._make_upstream()
+        picker = repo_picker.RepoPicker(
+            api_base_url="https://api.example",
+            api_token="tok",
+            lab_name="nmgrl",
+            alias="",
+        )
+        path = picker.open(
+            {
+                "repository_identifier": "X_001",
+                "ssh_url": upstream,
+                "default_branch": "main",
+            }
+        )
+        self.assertTrue(os.path.isfile(os.path.join(path, "README")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_ssh_config.py
+++ b/test/cloud/test_ssh_config.py
@@ -1,0 +1,121 @@
+"""Tests for pychron.cloud.ssh_config."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pychron.cloud import ssh_config
+
+
+class KnownHostsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._patcher = patch(
+            "pychron.cloud.paths.os.path.expanduser",
+            lambda p: p.replace("~", self.tmp),
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+        self.addCleanup(self._rmtree, self.tmp)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _read(self, path):
+        with open(path) as f:
+            return f.read()
+
+    def test_appends_when_absent(self):
+        from pychron.cloud.paths import known_hosts_path
+
+        line = "[forgejo.example]:2222 ssh-ed25519 AAAAC3..."
+        self.assertTrue(ssh_config.append_known_hosts_line(line))
+        self.assertIn(line, self._read(known_hosts_path()))
+
+    def test_idempotent_when_already_present(self):
+        line = "[forgejo.example]:2222 ssh-ed25519 AAAAC3..."
+        self.assertTrue(ssh_config.append_known_hosts_line(line))
+        # Second call returns False (no rewrite).
+        self.assertFalse(ssh_config.append_known_hosts_line(line))
+
+
+class SSHConfigBlockTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.path = os.path.join(self.tmp, "config")
+        self.addCleanup(self._rmtree, self.tmp)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _read(self):
+        with open(self.path) as f:
+            return f.read()
+
+    def _common_kw(self, alias="pychron-nmgrl"):
+        return dict(
+            alias=alias,
+            real_host="forgejo.example",
+            port=2222,
+            identity_file="/home/u/.pychron/keys/pychron_x",
+            known_hosts_file="/home/u/.pychron/known_hosts",
+            path=self.path,
+        )
+
+    def test_inserts_block_into_empty_file(self):
+        self.assertTrue(ssh_config.upsert_ssh_config_block(**self._common_kw()))
+        body = self._read()
+        self.assertIn("# BEGIN pychron-cloud:pychron-nmgrl", body)
+        self.assertIn("Host pychron-nmgrl", body)
+        self.assertIn("# END pychron-cloud:pychron-nmgrl", body)
+        self.assertIn("HostName forgejo.example", body)
+        self.assertIn("Port 2222", body)
+        self.assertIn("IdentitiesOnly yes", body)
+
+    def test_idempotent_on_repeat(self):
+        ssh_config.upsert_ssh_config_block(**self._common_kw())
+        first = self._read()
+        # Second call must not rewrite — returns False.
+        self.assertFalse(ssh_config.upsert_ssh_config_block(**self._common_kw()))
+        self.assertEqual(first, self._read())
+
+    def test_replaces_block_on_drift(self):
+        ssh_config.upsert_ssh_config_block(**self._common_kw())
+        kw = self._common_kw()
+        kw["port"] = 22  # drift
+        self.assertTrue(ssh_config.upsert_ssh_config_block(**kw))
+        body = self._read()
+        self.assertIn("Port 22", body)
+        self.assertNotIn("Port 2222", body)
+        # No duplicate BEGIN markers.
+        self.assertEqual(body.count("# BEGIN pychron-cloud:pychron-nmgrl"), 1)
+
+    def test_preserves_unrelated_content(self):
+        with open(self.path, "w") as f:
+            f.write("Host other\n    HostName other.example\n")
+        ssh_config.upsert_ssh_config_block(**self._common_kw())
+        body = self._read()
+        self.assertIn("Host other", body)
+        self.assertIn("HostName other.example", body)
+        self.assertIn("Host pychron-nmgrl", body)
+
+    def test_remove_block(self):
+        ssh_config.upsert_ssh_config_block(**self._common_kw())
+        self.assertTrue(ssh_config.remove_ssh_config_block("pychron-nmgrl", path=self.path))
+        body = self._read()
+        self.assertNotIn("pychron-cloud", body)
+        self.assertNotIn("Host pychron-nmgrl", body)
+
+    def test_remove_block_missing_returns_false(self):
+        with open(self.path, "w") as f:
+            f.write("Host other\n")
+        self.assertFalse(ssh_config.remove_ssh_config_block("pychron-nmgrl", path=self.path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_ssh_keygen.py
+++ b/test/cloud/test_ssh_keygen.py
@@ -1,0 +1,68 @@
+"""Tests for pychron.cloud.ssh_keygen."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pychron.cloud import ssh_keygen
+
+
+class SSHKeygenTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(self._rmtree, self.tmp)
+        # Redirect ~/.pychron under our tmp dir.
+        self._patcher = patch(
+            "pychron.cloud.paths.os.path.expanduser",
+            lambda p: p.replace("~", self.tmp),
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def test_generate_creates_both_files_with_secure_perms(self):
+        priv, pub = ssh_keygen.generate_keypair("testhost")
+        self.assertTrue(os.path.isfile(priv))
+        self.assertTrue(os.path.isfile(pub))
+        if os.name == "posix":
+            mode = os.stat(priv).st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+
+    def test_public_key_format_is_openssh_ed25519(self):
+        _, pub = ssh_keygen.generate_keypair("testhost")
+        with open(pub) as f:
+            line = f.read().strip()
+        self.assertTrue(line.startswith("ssh-ed25519 "))
+        # Comment field appended.
+        self.assertTrue(line.endswith("pychron-testhost"))
+
+    def test_ensure_keypair_is_idempotent(self):
+        priv, pub = ssh_keygen.ensure_keypair("testhost")
+        with open(priv, "rb") as f:
+            priv_bytes_first = f.read()
+        # Second call must not regenerate.
+        priv2, pub2 = ssh_keygen.ensure_keypair("testhost")
+        self.assertEqual(priv, priv2)
+        with open(priv, "rb") as f:
+            priv_bytes_second = f.read()
+        self.assertEqual(priv_bytes_first, priv_bytes_second)
+
+    def test_ensure_keypair_regenerates_when_pub_missing(self):
+        priv, pub = ssh_keygen.ensure_keypair("testhost")
+        with open(priv, "rb") as f:
+            first = f.read()
+        os.remove(pub)
+        ssh_keygen.ensure_keypair("testhost")
+        with open(priv, "rb") as f:
+            second = f.read()
+        # Private key was regenerated since the pair was incomplete.
+        self.assertNotEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_url_rewrite.py
+++ b/test/cloud/test_url_rewrite.py
@@ -1,0 +1,56 @@
+"""Tests for pychron.cloud.url_rewrite."""
+
+import unittest
+
+from pychron.cloud.url_rewrite import rewrite_to_alias
+
+
+class RewriteToAliasTestCase(unittest.TestCase):
+    def test_scp_form_rewritten(self):
+        self.assertEqual(
+            rewrite_to_alias("git@forgejo.example:nmgrl/X_001.git", "pychron-nmgrl"),
+            "pychron-nmgrl:nmgrl/X_001.git",
+        )
+
+    def test_scp_form_no_user(self):
+        self.assertEqual(
+            rewrite_to_alias("forgejo.example:nmgrl/X_001.git", "pychron-nmgrl"),
+            "pychron-nmgrl:nmgrl/X_001.git",
+        )
+
+    def test_ssh_uri_with_port(self):
+        self.assertEqual(
+            rewrite_to_alias("ssh://git@forgejo.example:2222/nmgrl/X_001.git", "pychron-nmgrl"),
+            "pychron-nmgrl:nmgrl/X_001.git",
+        )
+
+    def test_ssh_uri_no_port(self):
+        self.assertEqual(
+            rewrite_to_alias("ssh://git@forgejo.example/nmgrl/X.git", "pychron-nmgrl"),
+            "pychron-nmgrl:nmgrl/X.git",
+        )
+
+    def test_already_alias_form_passes_through(self):
+        self.assertEqual(
+            rewrite_to_alias("pychron-nmgrl:nmgrl/X.git", "pychron-nmgrl"),
+            "pychron-nmgrl:nmgrl/X.git",
+        )
+
+    def test_https_unchanged(self):
+        self.assertEqual(
+            rewrite_to_alias("https://forgejo.example/nmgrl/X.git", "pychron-nmgrl"),
+            "https://forgejo.example/nmgrl/X.git",
+        )
+
+    def test_empty_url_unchanged(self):
+        self.assertEqual(rewrite_to_alias("", "pychron-nmgrl"), "")
+
+    def test_empty_alias_passes_through(self):
+        self.assertEqual(
+            rewrite_to_alias("git@forgejo.example:nmgrl/X.git", ""),
+            "git@forgejo.example:nmgrl/X.git",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cloud/test_workstation_setup.py
+++ b/test/cloud/test_workstation_setup.py
@@ -1,0 +1,216 @@
+"""End-to-end tests for pychron.cloud.workstation_setup.WorkstationSetup."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pychron.cloud import api_client, workstation_setup
+
+
+def _registration(alias="pychron-nmgrl"):
+    return api_client.SSHKeyRegistration(
+        bot_username="lab-nmgrl-bot",
+        fingerprint="SHA256:xxx",
+        default_metadata_repo="lab-nmgrl/MetaData",
+        ssh_host_alias={
+            "alias": alias,
+            "real_host": "forgejo.example",
+            "port": 2222,
+            "known_hosts_line": "[forgejo.example]:2222 ssh-ed25519 AAAAC3...",
+        },
+        raw={
+            "bot_username": "lab-nmgrl-bot",
+            "fingerprint": "SHA256:xxx",
+            "default_metadata_repo": "lab-nmgrl/MetaData",
+            "ssh_host_alias": {
+                "alias": alias,
+                "real_host": "forgejo.example",
+                "port": 2222,
+                "known_hosts_line": "[forgejo.example]:2222 ssh-ed25519 AAAAC3...",
+            },
+        },
+    )
+
+
+class WorkstationSetupTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        # Redirect ~ → tmp so ~/.pychron and ~/.ssh land in scratch space.
+        self._patcher = patch(
+            "pychron.cloud.paths.os.path.expanduser",
+            lambda p: p.replace("~", self.tmp),
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+        self.addCleanup(self._rmtree, self.tmp)
+
+    def _rmtree(self, path):
+        import shutil
+
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _stub_register(self, **kw):
+        return patch.object(workstation_setup, "register_ssh_key", **kw)
+
+    def test_full_run_writes_all_artifacts(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="pcy_nmgrl_xyz",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self._stub_register(return_value=_registration()):
+            raw = ws.run()
+
+        self.assertEqual(raw["bot_username"], "lab-nmgrl-bot")
+
+        # Keypair on disk.
+        priv = os.path.join(self.tmp, ".pychron", "keys", "pychron_testhost")
+        self.assertTrue(os.path.isfile(priv))
+        self.assertTrue(os.path.isfile(priv + ".pub"))
+
+        # Registration persisted.
+        reg_path = os.path.join(self.tmp, ".pychron", "registration.json")
+        self.assertTrue(os.path.isfile(reg_path))
+        with open(reg_path) as f:
+            self.assertEqual(json.load(f)["bot_username"], "lab-nmgrl-bot")
+
+        # known_hosts has the line.
+        kh = os.path.join(self.tmp, ".pychron", "known_hosts")
+        with open(kh) as f:
+            self.assertIn("forgejo.example", f.read())
+
+        # ~/.ssh/config has the block.
+        sshc = os.path.join(self.tmp, ".ssh", "config")
+        with open(sshc) as f:
+            body = f.read()
+        self.assertIn("Host pychron-nmgrl", body)
+        self.assertIn("Port 2222", body)
+        self.assertIn("IdentityFile ", body)
+
+    def test_run_is_idempotent_on_repeat(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="pcy_nmgrl_xyz",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self._stub_register(return_value=_registration()):
+            ws.run()
+            priv = os.path.join(self.tmp, ".pychron", "keys", "pychron_testhost")
+            with open(priv, "rb") as f:
+                priv_first = f.read()
+            sshc = os.path.join(self.tmp, ".ssh", "config")
+            with open(sshc) as f:
+                config_first = f.read()
+            ws.run()
+            with open(priv, "rb") as f:
+                self.assertEqual(priv_first, f.read())
+            with open(sshc) as f:
+                self.assertEqual(config_first, f.read())
+
+    def test_fingerprint_rejected_rotates_key_and_retries(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="pcy_nmgrl_xyz",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        # First call: write a stale keypair so we can detect rotation.
+        from pychron.cloud import ssh_keygen
+
+        priv_path, pub_path = ssh_keygen.generate_keypair("testhost")
+        with open(priv_path, "rb") as f:
+            stale_priv = f.read()
+
+        with self._stub_register(
+            side_effect=[
+                api_client.CloudFingerprintRejected("dup"),
+                _registration(),
+            ]
+        ) as stub:
+            ws.run()
+            self.assertEqual(stub.call_count, 2)
+
+        with open(priv_path, "rb") as f:
+            self.assertNotEqual(stale_priv, f.read())
+
+    def test_missing_token_aborts(self):
+        ws = workstation_setup.WorkstationSetup(
+            api_base_url="https://api.example",
+            api_token="",
+            lab_name="nmgrl",
+            host="testhost",
+        )
+        with self.assertRaises(workstation_setup.WorkstationSetupError):
+            ws.run()
+
+    def test_load_registration_returns_none_when_absent(self):
+        self.assertIsNone(workstation_setup.load_registration())
+
+
+class APIClientRegisterTestCase(unittest.TestCase):
+    """Cover register_ssh_key error mapping."""
+
+    def _resp(self, status_code, json_body=None, text=""):
+        from unittest.mock import MagicMock
+
+        r = MagicMock()
+        r.status_code = status_code
+        r.text = text
+        if json_body is None:
+            r.json.side_effect = ValueError("not json")
+        else:
+            r.json.return_value = json_body
+        return r
+
+    def test_success(self):
+        body = {
+            "bot_username": "bot",
+            "fingerprint": "SHA256:x",
+            "default_metadata_repo": "lab/MetaData",
+            "ssh_host_alias": {
+                "alias": "pychron-nmgrl",
+                "real_host": "h",
+                "port": 22,
+                "known_hosts_line": "h ssh-ed25519 AAAA",
+            },
+        }
+        with patch.object(api_client.requests, "post", return_value=self._resp(201, body)):
+            reg = api_client.register_ssh_key(
+                "https://api.example", "tok", "ssh-ed25519 AAAA pychron-x"
+            )
+        self.assertEqual(reg.bot_username, "bot")
+        self.assertEqual(reg.alias, "pychron-nmgrl")
+
+    def test_401_maps_to_auth_error(self):
+        with patch.object(api_client.requests, "post", return_value=self._resp(401, text="x")):
+            with self.assertRaises(api_client.CloudAuthError):
+                api_client.register_ssh_key("https://api.example", "tok", "ssh-ed25519 AAAA")
+
+    def test_403_maps_to_permission_error(self):
+        with patch.object(api_client.requests, "post", return_value=self._resp(403, text="x")):
+            with self.assertRaises(api_client.CloudPermissionError):
+                api_client.register_ssh_key("https://api.example", "tok", "ssh-ed25519 AAAA")
+
+    def test_409_maps_to_fingerprint_rejected(self):
+        with patch.object(api_client.requests, "post", return_value=self._resp(409, text="dup")):
+            with self.assertRaises(api_client.CloudFingerprintRejected):
+                api_client.register_ssh_key("https://api.example", "tok", "ssh-ed25519 AAAA")
+
+    def test_422_maps_to_fingerprint_rejected(self):
+        with patch.object(
+            api_client.requests, "post", return_value=self._resp(422, text="bad key")
+        ):
+            with self.assertRaises(api_client.CloudFingerprintRejected):
+                api_client.register_ssh_key("https://api.example", "tok", "ssh-ed25519 AAAA")
+
+    def test_empty_public_key_raises(self):
+        with self.assertRaises(api_client.CloudAPIError):
+            api_client.register_ssh_key("https://api.example", "tok", "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -622,6 +622,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -631,6 +673,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -777,6 +836,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -1129,11 +1197,14 @@ dependencies = [
     { name = "cryptography" },
     { name = "envisage" },
     { name = "gitpython" },
+    { name = "google-auth" },
     { name = "jinja2" },
+    { name = "keyring" },
     { name = "lxml" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "peakutils" },
+    { name = "pg8000" },
     { name = "prometheus-client" },
     { name = "pygments" },
     { name = "pymysql" },
@@ -1202,11 +1273,14 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.3,<47" },
     { name = "envisage", specifier = ">=7.0.4,<8" },
     { name = "gitpython", specifier = ">=3.1.45,<4" },
+    { name = "google-auth", specifier = ">=2.30.0,<3" },
     { name = "jinja2", specifier = ">=3.1.6,<4" },
+    { name = "keyring", specifier = ">=25.0,<26" },
     { name = "lxml", specifier = ">=6.0.4,<7" },
     { name = "matplotlib", specifier = ">=3.10.8,<4" },
     { name = "numpy", specifier = ">=2.3.4,<3" },
     { name = "peakutils", specifier = ">=1.3.5,<2" },
+    { name = "pg8000", specifier = ">=1.31.2,<2" },
     { name = "prometheus-client", specifier = ">=0.25.0,<1" },
     { name = "pygments", specifier = ">=2.19.2,<3" },
     { name = "pymysql", specifier = ">=1.1.2,<2" },
@@ -1437,6 +1511,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1577,6 +1660,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/52/a866f1ac9ae9025ec7f9bea803bba9d54796f8a84236165a700831f61b27/scramp-1.4.8.tar.gz", hash = "sha256:bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71", size = 16630, upload-time = "2026-01-06T21:01:01.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/07/a962d2477331abfdb2c6a8251b65c673dbb07ad707d1882d61562b8b9147/scramp-1.4.8-py3-none-any.whl", hash = "sha256:87c2f15976845a2872fe5490a06097f0d01813cceb53774ea168c911f2ad025c", size = 13121, upload-time = "2026-01-06T21:00:59.474Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements client-side milestones P1, P2, P4, P6 of the [M7 Forgejo cloud onboarding plan](docs/architecture/forgejo-cloud-onboarding.md) and marks the M0-M6 Bridge for retirement.

- New `pychron.cloud` package wires the desktop client to pychronAPI for SSH key registration, repo discovery, and lifecycle management.
- M0-M6 `BridgeService` / `BridgePlugin` / `BridgePreferences` are flagged DEPRECATED, retire after P5 ships + pychronAPI register endpoint accepts the same metadata fields + NMGRL dogfood passes.

## What landed

### P1 — Settings + secret storage
- New "Pychron Cloud" preferences pane: `enable_pychron_cloud` flag, `api_base_url`, `lab_name`, `api_token`.
- Token kept in OS keyring (per lab); never written to `.cfg`.
- "Test Connection" hits `/api/v1/forgejo/whoami` and surfaces scope / lab-mismatch / 401 explicitly.

### P2 — SSH key lifecycle
- ed25519 keypair under `~/.pychron/keys/` (mode 0600).
- POST public key to `/api/v1/forgejo/workstations/ssh-keys`.
- Persist response to `~/.pychron/registration.json`.
- Append `known_hosts_line` to `~/.pychron/known_hosts`.
- Insert / replace sentinel-delimited `Host pychron-<lab>` block in `~/.ssh/config` (idempotent, drift-detected).
- Auto-rotate + retry on 409/422.

### P4 — DVC repo discovery (headless)
- `list_repositories(lab)` client; 404 → empty list.
- `rewrite_to_alias()` for SCP- and `ssh://`-form URLs to `pychron-<lab>:owner/repo`.
- `clone_or_pull()` under `~/Pychron/projects/<repo>` with origin-mismatch refusal.
- `last_repo` cache. **UI wiring deferred** — existing `SelectionPane` targets a different layout (`data/.dvc/repositories`); reconciling is its own PR.

### P6 — Token rotation, revocation, switch lab
- `WorkstationSetup.reonboard()`: force-rotate keypair + re-register; rewrites SSH config block on alias change.
- `WorkstationSetup.revoke_and_wipe()`: DELETE token, then erase local state; wipes locally even when server revoke fails.
- `switch_lab()`: destructive wipe including `~/Pychron/projects/`.
- Pane buttons "Re-onboard workstation", "Revoke this workstation", "Switch lab" with confirmation dialogs. Surfaces 401 for token re-entry (no silent retry).

## Out of scope here

- **P3** (MetaData clone) — deferred, plan still applies.
- **P5** (migration tool) — deferred; bridge retirement waits on this.
- **P7** (manual QA matrix) — by definition out of CI scope.

## Server prereqs (open in pychronAPI)

- `GET /api/v1/forgejo/labs/{name}/repositories` for P4 (plan note line 92-94).
- `DELETE /api/v1/forgejo/tokens/self` with cascade-delete to SSH key for P6.

## Test plan

- [x] `uv run --frozen python -m unittest discover -s test/cloud -t .` — 102 / 102 pass.
- [ ] Manual: open prefs in built app, save token, verify keyring entry exists and `.cfg` does not contain it.
- [ ] Manual: "Test Connection" against a staging pychronAPI; verify each error path renders correctly.
- [ ] Manual on macOS / Linux / Windows: P2 onboarding writes `~/.pychron/keys/`, `~/.pychron/known_hosts`, and a `Host pychron-<lab>` block in `~/.ssh/config`; `git ls-remote pychron-<lab>:lab/repo.git` succeeds.
- [ ] Manual: P6 "Revoke" then attempt onboarding again — expect fresh SSH key + new server-side row.
- [ ] Manual: P6 "Switch lab" wipes `~/Pychron/projects/` and prompts for new lab inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)