### PR TITLE
perf(dvc): reuse IAM Connector + larger warm pool + outer session_ctx

### DIFF
--- a/pychron/database/core/database_adapter.py
+++ b/pychron/database/core/database_adapter.py
@@ -598,15 +598,17 @@ host= {}\nurl= {}'.format(
 
         # Cloud SQL Connector pays a fixed cost per fresh connection
         # (OAuth token mint + sqladmin metadata fetch + tunnel setup),
-        # so keep a small warm pool around to amortize. pool_pre_ping
-        # would add an extra round-trip per checkout — skip it; the
-        # pool_recycle window is short enough to evict stale conns.
+        # so keep a larger warm pool around to amortize across bursty
+        # UI flows. Override caller's pool_recycle floor — short recycle
+        # windows evict warm conns faster than IAM token TTL requires
+        # and force repeated cold-path connects.
+        iam_recycle = max(pool_recycle, 1800)
         return create_engine(
             url,
             echo=self.echo,
-            pool_recycle=pool_recycle,
+            pool_recycle=iam_recycle,
             creator=get_connection,
-            pool_size=5,
+            pool_size=10,
             max_overflow=10,
             pool_pre_ping=False,
         )
@@ -670,7 +672,13 @@ host= {}\nurl= {}'.format(
         if credentials is not None:
             kw["credentials"] = credentials
 
-        self._close_cloudsql_connector()
+        # Reuse existing Connector — it owns the OAuth token cache and a
+        # background refresh task. Closing/recreating per connect() drops
+        # both and forces a fresh sqladmin fetch on the next connection.
+        # reset_connection() still closes it when params actually change.
+        if self._cloudsql_connector is not None:
+            return self._cloudsql_connector
+
         self._cloudsql_connector = Connector(**kw)
         return self._cloudsql_connector
 

--- a/pychron/dvc/dvc.py
+++ b/pychron/dvc/dvc.py
@@ -636,22 +636,28 @@ class DVC(Loggable):
 
     def repository_transfer(self, ans, dest):
         destrepo = self._get_repository(dest, as_current=False)
-        for src, ais in groupby_repo(ans):
-            repo = self._get_repository(src, as_current=False)
-            for ai in ais:
-                ops, nps = self._transfer_analysis_to(dest, src, ai.runid)
-                repo.add_paths(ops)
-                destrepo.add_paths(nps)
+        # Outer session_ctx so the per-analysis get_analysis_uuid() calls
+        # below all reuse one DB connection checkout. Without this, each
+        # call returns its connection to the pool — a per-call hit on
+        # Cloud SQL IAM where every cold pool checkout pays the connector
+        # setup cost.
+        with self.db.session_ctx():
+            for src, ais in groupby_repo(ans):
+                repo = self._get_repository(src, as_current=False)
+                for ai in ais:
+                    ops, nps = self._transfer_analysis_to(dest, src, ai.runid)
+                    repo.add_paths(ops)
+                    destrepo.add_paths(nps)
 
-                # update database
-                dbai = self.db.get_analysis_uuid(ai.uuid)
-                for ri in dbai.repository_associations:
-                    if ri.repository == src:
-                        ri.repository = dest
+                    # update database
+                    dbai = self.db.get_analysis_uuid(ai.uuid)
+                    for ri in dbai.repository_associations:
+                        if ri.repository == src:
+                            ri.repository = dest
 
-            # commit src changes
-            repo.commit("Transferred analyses to {}".format(dest))
-            dest.commit("Transferred analyses from {}".format(src))
+                # commit src changes
+                repo.commit("Transferred analyses to {}".format(dest))
+                dest.commit("Transferred analyses from {}".format(src))
 
     def get_flux(self, irrad, level, pos):
         fd = self.meta_repo.get_flux(irrad, level, pos)
@@ -1188,10 +1194,16 @@ class DVC(Loggable):
                 )
                 self.debug_exception()
 
-        if use_progress:
-            ret = progress_loader(records, func, threshold=1, step=25)
-        else:
-            ret = [func(r, None, 0, 0) for r in records]
+        # Hold a single DB connection across the per-record fan-out.
+        # _make_record() calls self.db.get_analysis_uuid() per record;
+        # without this outer session_ctx each call returns its connection
+        # to the pool and the next record re-checks one out — on Cloud
+        # SQL IAM cold-pool checkout pays the connector setup cost.
+        with self.db.session_ctx():
+            if use_progress:
+                ret = progress_loader(records, func, threshold=1, step=25)
+            else:
+                ret = [func(r, None, 0, 0) for r in records]
 
         make_et = time.perf_counter()
         et = make_et - st

--- a/pychron/dvc/dvc_database.py
+++ b/pychron/dvc/dvc_database.py
@@ -1007,10 +1007,24 @@ class DVCDatabase(DatabaseAdapter):
             return [a.analysis for a in r.repository_associations]
 
     def get_identifier_info(self, li):
-        with self.session_ctx():
+        with self.session_ctx() as sess:
             info = {}
 
-            dbpos = self.get_identifier(li)
+            # Eager-load level→irradiation and sample→{material, project→PI}
+            # in one round trip. Avoids 3+ lazy fetches downstream — costly
+            # on Cloud SQL IAM where each cold conn is 200-500ms.
+            q = sess.query(IrradiationPositionTbl).options(
+                joinedload(IrradiationPositionTbl.level).joinedload(LevelTbl.irradiation),
+                joinedload(IrradiationPositionTbl.sample).joinedload(SampleTbl.material),
+                joinedload(IrradiationPositionTbl.sample)
+                .joinedload(SampleTbl.project)
+                .joinedload(ProjectTbl.principal_investigator),
+            )
+            q = q.filter(IrradiationPositionTbl.identifier == li)
+            try:
+                dbpos = q.one()
+            except NoResultFound:
+                dbpos = None
             if not dbpos:
                 self.warning("{} is not an identifier in the database".format(li))
                 return None


### PR DESCRIPTION
## Summary

Tier 1 of Cloud SQL IAM perf plan. Recent N+1 fixes (bulk prefetch, single MIN/MAX) did not close the gap because the dominant cost was **per-fresh-connection**: Cloud SQL Python Connector pays an OAuth token mint + `sqladmin.googleapis.com` metadata fetch + TLS tunnel setup on every cold pool checkout. Bursty UI flows kept falling off the warm pool and re-paying that.

## Changes

- **Reuse `Connector` singleton across `connect()` calls** (`database_adapter.py`). `_make_cloudsql_connector` previously closed and rebuilt the connector on every reconnect, blowing away its OAuth token cache and background refresh task. Now returns the existing one; `reset_connection()` still closes it when params actually change.
- **Bump IAM pool size + recycle window** (`database_adapter.py`). `pool_size` 5 -> 10 absorbs UI + worker contention; `pool_recycle` floored at 1800s so warm conns survive short idle gaps. IAM token TTL is handled independently by the connector's lazy-refresh strategy.
- **Joinedload chain in `get_identifier_info`** (`dvc_database.py`). One query (level->irradiation, sample->{material, project->PI}) replaces three+ lazy attribute fetches. Mirrors the pattern from `_prefetch_analysis_relations`.
- **Outer `session_ctx` around fan-out call sites** (`dvc.py`):
  - `make_analyses`: per-record loop calls `db.get_analysis_uuid()` inside `_make_record`. Without an outer session each call returned its conn to the pool. Now one checkout for the whole batch.
  - `repository_transfer`: nested per-analysis `get_analysis_uuid()` loop. Same fix.
  - `SessionCTX` already refcounts, so existing inner `session_ctx` calls become refcount bumps — no behaviour change beyond the connection-reuse win.

## Reviewer notes

- No schema changes, no migration risk.
- `pool_recycle` change uses `max(caller_value, 1800)` so legacy callers passing smaller values get the floor, but anyone passing larger keeps theirs.
- `Connector` reuse only short-circuits when `_cloudsql_connector` is non-None. `reset_connection()` (triggered by trait change on auth params) still nulls it.
- Plan doc at `~/.claude/plans/pychron-now-can-use-virtual-anchor.md` covers Tier 2 (Cloud SQL Auth Proxy sidecar) for a follow-up if measured gains here fall short.

## Test plan

- [ ] Connect to Cloud SQL IAM DB cold-start, confirm one connector init in logs (was: one per `connect()` invocation).
- [ ] Run a `make_analyses` batch (50+ analyses). Check `Make analysis time` debug log — expect 2-5x improvement on bursty paths.
- [ ] Recall an analysis, observe `dvc.perf` instrumentation timings.
- [ ] Verify `engine.pool.status()` shows warm pool staying warm (checked-in count near `pool_size`).
- [ ] Confirm `reset_connection()` still drops the connector when auth params change (toggle preference, reconnect).
- [ ] Existing tests pass (no functional change expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)