### PR TITLE
fix: serialize NGX read_intensities and stop unactivated ScanManager …

### DIFF
--- a/pychron/managers/stream_graph_manager.py
+++ b/pychron/managers/stream_graph_manager.py
@@ -65,7 +65,7 @@ class StreamGraphManager(Manager):
     timer = None
     update_period = 2
     _signal_failed_cnt = 0
-    _streaming_active = True
+    _streaming_active = False
 
     def stop(self):
         self.prepare_destroy()

--- a/pychron/spectrometer/isotopx/spectrometer/ngx.py
+++ b/pychron/spectrometer/isotopx/spectrometer/ngx.py
@@ -189,11 +189,18 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
         self.ask(f"SetSourceOutput {name},{value}")
 
     def read_intensities(self, timeout=60, trigger=False, target="ACQ.B", verbose=True):
-        # self.microcontroller.lock.acquire()
-        # verbose=True
-        self._read_enabled = True
+        # Serialize the trigger+readline cycle. Multiple threads can call this
+        # concurrently (ScanManager timer + AutomatedRun MultiCollector). Without
+        # the lock, two threads race trigger_acq (duplicate StartAcq -> E43) and
+        # interleave bytes when reading the shared TCP socket (garbled records).
+        lock = self.microcontroller.lock
+        if lock is None:
+            return self._read_intensities(trigger=trigger, verbose=verbose)
+        with lock:
+            return self._read_intensities(trigger=trigger, verbose=verbose)
 
-        # verbose = True
+    def _read_intensities(self, trigger=False, verbose=True):
+        self._read_enabled = True
 
         if verbose:
             self.debug(
@@ -202,40 +209,21 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
                 )
             )
 
-        # self.microcontroller.lock.acquire()
         resp = True
-        # trigger_release = self.triggered_lock_release_required
-        # self.debug(f'trigger={trigger} triggered={self.microcontroller.triggered} '
-        #            f'triggered_locrelease_required={self.triggered_lock_release_required}')
-        # print('treigger', trigger, self.microcontroller.triggered)
         if trigger or not self.microcontroller.triggered:
             resp = self.trigger_acq()
-            # trigger_release = self.microcontroller.triggered
-            # self.debug(f'trigger_relase={trigger_release}')
-
-            # self.microcontroller.lock.release()
             if resp is not None:
-                # if verbose:
-                #     self.debug(f'waiting {self.integration_time * 0.95} before trying to get data')
-                # time.sleep(self.integration_time * 0.95)
                 time.sleep(0.95)
-                # if verbose:
-                #     self.debug('trigger wait finished')
-        # else:
-        # self.microcontroller.lock.acquire()
-        # self.triggered_lock_release_required = True
 
         keys = []
         signals = []
         collection_time = None
         inc = False
-        # self.debug(f'acquired mcir lock {self.microcontroller.lock}')
         targetb = "#EVENT:ACQ.B,{}".format(self.rcs_id)
         targeta = "#EVENT:ACQ,{}".format(self.rcs_id)
         if resp is not None:
             keys = self.detector_names[::-1]
             while self._read_enabled:
-                # with self.microcontroller.lock:
                 line = self.readline(verbose=verbose)
 
                 if verbose:
@@ -259,7 +247,6 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
                                 self.acq_count == self.total_acq_count
                                 and self.has_atonas
                             ):
-                                # forget this ACQ and immediately get the ACQ.B record.
                                 continue
                             else:
                                 nsignals, keys = [], []
@@ -285,7 +272,6 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
                     except BaseException as e:
                         self.debug("read intensities errror={}".format(e))
 
-        # self.microcontroller.lock.release()
         if len(signals) != len(keys):
             self.debug("keys={}".format(keys))
             self.debug("signals".format(signals))
@@ -300,40 +286,6 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
             self.debug("collection time: {}".format(collection_time))
             self.debug("keys: {}".format(keys))
             self.debug("signals: {}".format(signals))
-
-        # try:
-        #     # the integration cycle is complete. release the lock
-        #     if inc:
-        #         self.microcontroller.lock.release()
-        #         self.debug(f'Released lock. {self.microcontroller.lock}')
-        # except RuntimeError as e:
-        #     self.debug(f'Cannot release lock. "RuntimeError" {e}')
-
-        # if self.triggered_lock_release_required:
-        #     self.triggered_lock_release_required = False
-        #     if trigger_release:
-        # if self.microcontroller.lock.active_count() > 0:
-        #     self.debug(f"trigger release. lock count={self.microcontroller.lock.count}")
-        #     self.microcontroller.lock.release()
-        # self.debug(f'trigger release. {trigger_release}')
-        # if trigger_release:
-        # self.triggered_lock_release_required = False
-
-        # if self.microcontroller.lock.count>0:
-        #     try:
-        #         self.microcontroller.lock.release()
-        #     except RuntimeError as e:
-        #         if verbose:
-        #             self.debug(f'Trigger Release. Cannot release lock. "RuntimeError" {e}')
-        #     self.microcontroller.lock.release()
-        # except RuntimeError as e:
-        #     self.debug(f'Cannot release lock. "RuntimeError" {e}')
-        #
-        # if trigger_release:
-        #     try:
-        #         self.microcontroller.lock.release()
-        #     except RuntimeError as e:
-        #         self.debug(f'Trigger Release. Cannot release lock. "RuntimeError" {e}')
 
         return keys, signals, collection_time, inc
 

--- a/pychron/spectrometer/scan_manager.py
+++ b/pychron/spectrometer/scan_manager.py
@@ -555,10 +555,17 @@ class ScanManager(StreamGraphManager):
             #     t.start()
 
     def _integration_time_changed(self):
+        # Skip when the scan window has never been activated. integration_time
+        # is a DelegatesTo proxy on the spectrometer, so AutomatedRun setting
+        # the spectrometer integration time also fires this notification on the
+        # singleton ScanManager. Without this gate, the unactivated ScanManager
+        # would (a) re-issue StopAcq/SetAcqPeriod and (b) auto-create a scan
+        # timer that races the measurement thread on the shared TCP socket.
+        if not self._streaming_active:
+            return
         if self.integration_time:
             self.debug("scan manager.setting integration time={}".format(self.integration_time))
             if not self.timer or self.spectrometer.reset_scan_timer_on_integration:
-                #if self._is_active:
                 self.spectrometer.set_integration_time(
                     self.integration_time, force=True
                 )


### PR DESCRIPTION
…from starting scan timer

NGX socket reads were racing between MultiCollector and ScanManager Timer threads, garbling TCP bytes and triggering duplicate StartAcq (E43) once integration_time changed mid-run.

- Wrap NGX read_intensities in microcontroller.lock so trigger_acq + readline cycles serialize across threads. The lock was already initialized in NGXController but every call site was commented out. ask() uses a separate communicator lock so valve/source commands are unaffected.
- Default _streaming_active to False so the plugin-instantiated singleton ScanManager does not start a scan timer until activate() runs (window opens).
- Gate _integration_time_changed on _streaming_active to skip the redundant StopAcq/SetAcqPeriod and the auto reset_scan_timer fired by the DelegatesTo notification when AutomatedRun changes spectrometer.integration_time.

## Summary

- Describe the user-facing or developer-facing change.
- Keep this focused on what changed and why.

## Context

- Why is this change needed?
- What problem does it solve?

## Verification

- [ ] Tests added or updated where appropriate
- [ ] Local verification completed
- [ ] CI is expected to pass

Verification details:

- `...`

## Risk

- Note behavioral risk, migration risk, hardware risk, or data risk.
- If low risk, say so explicitly.

## Target Branch Check

- [ ] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`)

## Follow-ups

- Optional follow-up work, cleanup, or known limitations.

