### PR TITLE
feat(flux): 1-D bracketing regressor + NN linear interpolation fixes

### DIFF
--- a/pychron/core/regression/flux_regressor.py
+++ b/pychron/core/regression/flux_regressor.py
@@ -23,11 +23,12 @@ from numpy import (
     column_stack,
     ones_like,
     ravel,
+    searchsorted,
     zeros_like,
 )
 from scipy.interpolate import Rbf, bisplev, bisplrep, griddata
 from statsmodels.regression.linear_model import OLS, WLS
-from traits.api import Bool, Enum, Int
+from traits.api import Bool, Enum, Int, Str
 
 from pychron.core.geometry.geometry import calc_distances
 from pychron.core.regression.base_regressor import BaseRegressor
@@ -123,11 +124,20 @@ class IDWRegressor(InterpolationRegressor):
         return self._invdisttree(pts, nnear=nnear, eps=eps, p=p)
 
 
-def linear_interp(xy, xs, js):
-    """Linear interpolate js[0..1] over the distance from xs[0] to (xy projected onto xs[0..1])."""
-    x2 = ((xs[0][0] - xs[1][0]) ** 2 + (xs[0][1] - xs[1][1]) ** 2) ** 0.5
-    x = ((xy[0] - xs[0][0]) ** 2 + (xy[1] - xs[0][1]) ** 2) ** 0.5
-    return js[0] + x * (js[1] - js[0]) / x2
+def lever_fraction(xy, p0, p1):
+    """Fraction of ``xy`` projected onto the segment p0->p1 (0 at p0, 1 at p1).
+
+    Uses the scalar projection (dot product) so an unknown that is off the
+    p0-p1 line is handled correctly; the previous Euclidean-distance version
+    always returned a non-negative magnitude and so could not represent a
+    point lying "before" p0. The fraction is left unclamped so points outside
+    the pair extrapolate linearly.
+    """
+    dx, dy = p1[0] - p0[0], p1[1] - p0[1]
+    d2 = dx * dx + dy * dy
+    if d2 == 0:
+        return 0.0
+    return ((xy[0] - p0[0]) * dx + (xy[1] - p0[1]) * dy) / d2
 
 
 class NearestNeighborFluxRegressor(SpecialFluxRegressor):
@@ -167,9 +177,94 @@ class NearestNeighborFluxRegressor(SpecialFluxRegressor):
         if style == AVERAGE:
             return vs.std() if return_error else vs.mean()
         if style == LINEAR:
-            src = self.clean_yserr[idx] if return_error else self.clean_ys[idx]
-            return linear_interp((x, y), self.clean_xs[idx], src)
+            p0, p1 = self.clean_xs[idx][0], self.clean_xs[idx][-1]
+            f = lever_fraction((x, y), p0, p1)
+            if return_error:
+                e0, e1 = self.clean_yserr[idx][0], self.clean_yserr[idx][-1]
+                # propagate in quadrature, weighted by fractional distance
+                return (((1 - f) * e0) ** 2 + (f * e1) ** 2) ** 0.5
+            j0, j1 = vs[0], vs[-1]
+            return j0 + f * (j1 - j0)
         return 0
+
+
+class Bracketing1DRegressor(SpecialFluxRegressor):
+    """1-D bracketing flux model (lever-rule interpolation).
+
+    Monitors are positioned along a single coordinate (``xs`` is 1-D; the
+    caller projects 2-D tray positions onto the chosen axis). For an unknown
+    at coordinate ``p`` the straddling monitor pair (one below, one above) is
+    located and J is linearly interpolated between them (the lever rule):
+
+        f = (p - x0) / (x1 - x0)
+        j = y0 + f * (y1 - y0)
+
+    The error is propagated in quadrature, weighting each monitor by its
+    fractional distance::
+
+        jerr = sqrt(((1 - f) * e0)^2 + (f * e1)^2)
+
+    Outside the monitor range the nearest end pair's slope is extrapolated
+    (``f`` is allowed outside [0, 1]).
+    """
+
+    one_d_axis = Str("X")
+    _order = None
+    _sxs = None
+    _sys = None
+    _ses = None
+
+    def calculate(self):
+        # sort once; order maps sorted index -> original monitor index so
+        # set_neighbors can report the bracketing monitors' hole ids.
+        self._order = argsort(self.clean_xs)
+        self._sxs = self.clean_xs[self._order]
+        self._sys = self.clean_ys[self._order]
+        self._ses = self.clean_yserr[self._order]
+
+    def _bracket_indices(self, p):
+        """Return (lo, hi, f) in sorted-index space for coordinate ``p``.
+
+        lo/hi straddle ``p`` when in range; at/below the low end the first
+        pair (0, 1) is used and above the high end the last pair, so ``f``
+        extrapolates past the ends.
+        """
+        sxs = self._sxs
+        n = sxs.shape[0]
+        hi = int(searchsorted(sxs, p))
+        if hi <= 0:
+            lo, hi = 0, 1
+        elif hi >= n:
+            lo, hi = n - 2, n - 1
+        else:
+            lo = hi - 1
+
+        x0, x1 = sxs[lo], sxs[hi]
+        f = 0.0 if x1 == x0 else (p - x0) / (x1 - x0)
+        return lo, hi, f
+
+    def _predict_one(self, p, return_error):
+        lo, hi, f = self._bracket_indices(p)
+        if return_error:
+            e0, e1 = self._ses[lo], self._ses[hi]
+            return (((1 - f) * e0) ** 2 + (f * e1) ** 2) ** 0.5
+        y0, y1 = self._sys[lo], self._sys[hi]
+        return y0 + f * (y1 - y0)
+
+    def _predict(self, pts, return_error=False):
+        if self._sxs.shape[0] < 2:
+            return zeros_like(asarray(pts, dtype=float))
+        return [self._predict_one(float(p), return_error) for p in pts]
+
+    def set_neighbors(self, unks, mons):
+        if self._sxs.shape[0] < 2:
+            return
+        order = self._order
+        for unk in unks:
+            p = unk.x if self.one_d_axis == "X" else unk.y
+            lo, hi, _ = self._bracket_indices(float(p))
+            unk.bracket_a = mons[order[lo]].hole_id
+            unk.bracket_b = mons[order[hi]].hole_id
 
 
 class BowlFluxRegressor(MultipleLinearRegressor):

--- a/pychron/core/regression/flux_regressor.py
+++ b/pychron/core/regression/flux_regressor.py
@@ -209,10 +209,6 @@ class Bracketing1DRegressor(SpecialFluxRegressor):
     """
 
     one_d_axis = Str("X")
-    _order = None
-    _sxs = None
-    _sys = None
-    _ses = None
 
     def calculate(self):
         # sort once; order maps sorted index -> original monitor index so

--- a/pychron/core/regression/flux_regressor.py
+++ b/pychron/core/regression/flux_regressor.py
@@ -26,14 +26,14 @@ from numpy import (
     searchsorted,
     zeros_like,
 )
-from scipy.interpolate import Rbf, bisplev, bisplrep, griddata
-from statsmodels.regression.linear_model import OLS, WLS
+from scipy.interpolate import Rbf, bisplev, bisplrep, griddata  # type: ignore
+from statsmodels.regression.linear_model import OLS, WLS  # type: ignore
 from traits.api import Bool, Enum, Int, Str
 
 from pychron.core.geometry.geometry import calc_distances
 from pychron.core.regression.base_regressor import BaseRegressor
 from pychron.core.regression.ols_regressor import MultipleLinearRegressor
-from pychron.core.stats.idw import Invdisttree
+from pychron.core.stats.idw import Invdisttree  # type: ignore
 from pychron.pychron_constants import AVERAGE, LINEAR, WEIGHTED_MEAN
 
 

--- a/pychron/core/regression/tests/regression.py
+++ b/pychron/core/regression/tests/regression.py
@@ -546,7 +546,8 @@ class Bracketing1DRegressionTest(TestCase):
         self.xs = array([0.0, 10.0, 20.0])
         self.ys = array([1.0, 2.0, 4.0])
         self.es = array([0.1, 0.2, 0.4])
-        self.reg = Bracketing1DRegressor(xs=self.xs, ys=self.ys, yserr=self.es)
+        self.reg = Bracketing1DRegressor()
+        self.reg.trait_set(xs=self.xs, ys=self.ys, yserr=self.es)
         self.reg.calculate()
 
     def _predict(self, p):

--- a/pychron/core/regression/tests/regression.py
+++ b/pychron/core/regression/tests/regression.py
@@ -31,6 +31,10 @@ from pychron.core.regression.new_york_regressor import (
     NewYorkRegressor,
 )
 from pychron.core.regression.ols_regressor import OLSRegressor
+from pychron.core.regression.flux_regressor import (
+    Bracketing1DRegressor,
+    NearestNeighborFluxRegressor,
+)
 
 # from pychron.core.regression.york_regressor import YorkRegressor
 from pychron.core.regression.tests.standard_data import (
@@ -234,9 +238,7 @@ class PearsonRegressionTest(RegressionTestCase):
 
     def test_slope_err(self):
         exp = pearson(self.kind)
-        self.assertAlmostEqual(
-            self.reg.get_slope_variance() ** 0.5, exp["slope_err"], 4
-        )
+        self.assertAlmostEqual(self.reg.get_slope_variance() ** 0.5, exp["slope_err"], 4)
 
     def test_y_intercept(self):
         expected = pearson(self.kind)
@@ -244,9 +246,7 @@ class PearsonRegressionTest(RegressionTestCase):
 
     def test_y_intercept_error(self):
         expected = pearson(self.kind)
-        self.assertAlmostEqual(
-            self.reg.get_intercept_error(), expected["intercept_err"], 4
-        )
+        self.assertAlmostEqual(self.reg.get_intercept_error(), expected["intercept_err"], 4)
 
     def test_mswd(self):
         expected = pearson(self.kind)
@@ -275,21 +275,15 @@ class ExpoRegressionTest(TestCase):
 
     def test_a(self):
         self.reg.calculate()
-        self.assertAlmostEqual(
-            self.reg.coefficients[0], self.solution["coefficients"][0]
-        )
+        self.assertAlmostEqual(self.reg.coefficients[0], self.solution["coefficients"][0])
 
     def test_b(self):
         self.reg.calculate()
-        self.assertAlmostEqual(
-            self.reg.coefficients[1], self.solution["coefficients"][1]
-        )
+        self.assertAlmostEqual(self.reg.coefficients[1], self.solution["coefficients"][1])
 
     def test_c(self):
         self.reg.calculate()
-        self.assertAlmostEqual(
-            self.reg.coefficients[2], self.solution["coefficients"][2]
-        )
+        self.assertAlmostEqual(self.reg.coefficients[2], self.solution["coefficients"][2])
 
 
 class ExpoRegressionTest2(TestCase):
@@ -300,9 +294,41 @@ class ExpoRegressionTest2(TestCase):
 
     def test_c(self):
         self.reg.calculate()
-        self.assertAlmostEqual(
-            self.reg.coefficients[2], self.solution["coefficients"][2], places=5
+        self.assertAlmostEqual(self.reg.coefficients[2], self.solution["coefficients"][2], places=5)
+
+
+class NearestNeighborLinearTest(TestCase):
+    """2-D bracketing (NN n=2, LINEAR): projection fraction + quadrature error."""
+
+    def setUp(self):
+        from numpy import array
+        from pychron.pychron_constants import LINEAR
+
+        self.reg = NearestNeighborFluxRegressor(
+            xs=array([[0.0, 0.0], [10.0, 0.0]]),
+            ys=array([1.0, 2.0]),
+            yserr=array([0.1, 0.2]),
+            n=2,
+            interpolation_style=LINEAR,
         )
+        self.reg.calculate()
+
+    def test_midpoint_value(self):
+        from numpy import array
+
+        self.assertAlmostEqual(self.reg.predict(array([[5.0, 0.0]]))[0], 1.5, 6)
+
+    def test_error_quadrature(self):
+        from numpy import array
+
+        expected = (((0.5 * 0.1) ** 2) + ((0.5 * 0.2) ** 2)) ** 0.5
+        self.assertAlmostEqual(self.reg.predict_error(array([[5.0, 0.0]]))[0], expected, 9)
+
+    def test_offline_projection(self):
+        from numpy import array
+
+        # an unknown off the monitor line still projects to f=0.5
+        self.assertAlmostEqual(self.reg.predict(array([[5.0, 3.0]]))[0], 1.5, 6)
 
 
 # ============= EOF =============================================
@@ -508,3 +534,81 @@ class ExpoRegressionTest2(TestCase):
 # #        print y, yal
 #        self.assertEqual(y, self.Yprederr_5_parabolic)
 # #        self.assertEqual(yal, self.Yprederr_5_parabolic)
+
+
+class Bracketing1DRegressionTest(TestCase):
+    """Lever-rule 1-D bracketing: interpolation, quadrature error, extrapolation."""
+
+    def setUp(self):
+        from numpy import array
+
+        # monitors along a single axis
+        self.xs = array([0.0, 10.0, 20.0])
+        self.ys = array([1.0, 2.0, 4.0])
+        self.es = array([0.1, 0.2, 0.4])
+        self.reg = Bracketing1DRegressor(xs=self.xs, ys=self.ys, yserr=self.es)
+        self.reg.calculate()
+
+    def _predict(self, p):
+        from numpy import array
+
+        return self.reg.predict(array([p]))[0]
+
+    def _predict_error(self, p):
+        from numpy import array
+
+        return self.reg.predict_error(array([p]))[0]
+
+    def test_interpolate_midpoint(self):
+        # f=0.5 between (0,1) and (10,2)
+        self.assertAlmostEqual(self._predict(5.0), 1.5, 6)
+
+    def test_interpolate_quarter(self):
+        # f=0.25 between (0,1) and (10,2)
+        self.assertAlmostEqual(self._predict(2.5), 1.25, 6)
+
+    def test_error_quadrature(self):
+        # sqrt(((1-0.5)*0.1)^2 + (0.5*0.2)^2)
+        expected = (((0.5 * 0.1) ** 2) + ((0.5 * 0.2) ** 2)) ** 0.5
+        self.assertAlmostEqual(self._predict_error(5.0), expected, 9)
+
+    def test_exact_on_node(self):
+        self.assertAlmostEqual(self._predict(10.0), 2.0, 6)
+        self.assertAlmostEqual(self._predict(0.0), 1.0, 6)
+        self.assertAlmostEqual(self._predict(20.0), 4.0, 6)
+
+    def test_extrapolate_below(self):
+        # below range uses pair (0,10): f=-1 -> 1 + (-1)*(2-1) = 0
+        self.assertAlmostEqual(self._predict(-10.0), 0.0, 6)
+
+    def test_extrapolate_above(self):
+        # above range uses pair (10,20): f=2 -> 2 + 2*(4-2) = 6
+        self.assertAlmostEqual(self._predict(30.0), 6.0, 6)
+
+    def test_unsorted_input(self):
+        from numpy import array
+
+        reg = Bracketing1DRegressor(
+            xs=array([20.0, 0.0, 10.0]),
+            ys=array([4.0, 1.0, 2.0]),
+            yserr=array([0.4, 0.1, 0.2]),
+        )
+        reg.calculate()
+        self.assertAlmostEqual(reg.predict(array([5.0]))[0], 1.5, 6)
+
+    def test_set_neighbors(self):
+        class P:
+            def __init__(self, x, hid):
+                self.x = x
+                self.y = 0.0
+                self.hole_id = hid
+                self.bracket_a = None
+                self.bracket_b = None
+
+        mons = [P(0.0, "m0"), P(10.0, "m1"), P(20.0, "m2")]
+        reg = Bracketing1DRegressor(xs=self.xs, ys=self.ys, yserr=self.es, one_d_axis="X")
+        reg.calculate()
+        unk = P(5.0, "u0")
+        reg.set_neighbors([unk], mons)
+        self.assertEqual(unk.bracket_a, "m0")
+        self.assertEqual(unk.bracket_b, "m1")

--- a/pychron/options/views/flux_views.py
+++ b/pychron/options/views/flux_views.py
@@ -41,7 +41,7 @@ class FluxSubOptions(SubOptions):
             Item("selected_monitor", label="Flux Const."),
             Readonly(
                 "lambda_k",
-                format_func=lambda x: "{:0.3u}".format(x),
+                format_func=lambda x: "{:0.3u}".format(x),  # type: ignore[str-format]
                 label="Total \u03bb K",
             ),
             Readonly("monitor_age"),

--- a/pychron/options/views/flux_views.py
+++ b/pychron/options/views/flux_views.py
@@ -26,6 +26,7 @@ from pychron.pychron_constants import (
     LEAST_SQUARES_1D,
     WEIGHTED_MEAN_1D,
     BRACKETING,
+    BRACKETING_1D,
     NN,
     MATCHING,
     HIGH_ORDER_POLY,
@@ -41,7 +42,7 @@ class FluxSubOptions(SubOptions):
             Readonly(
                 "lambda_k",
                 format_func=lambda x: "{:0.3u}".format(x),
-                label="Total \u03BB K",
+                label="Total \u03bb K",
             ),
             Readonly("monitor_age"),
             BorderVGroup(
@@ -62,8 +63,8 @@ class FluxSubOptions(SubOptions):
                 Item(
                     "one_d_axis",
                     label="Axis",
-                    visible_when='model_kind in ("{}","{}")'.format(
-                        LEAST_SQUARES_1D, WEIGHTED_MEAN_1D
+                    visible_when='model_kind in ("{}","{}","{}")'.format(
+                        LEAST_SQUARES_1D, WEIGHTED_MEAN_1D, BRACKETING_1D
                     ),
                 ),
                 Item(

--- a/pychron/pipeline/editors/flux_visualization_editor.py
+++ b/pychron/pipeline/editors/flux_visualization_editor.py
@@ -54,6 +54,7 @@ from pychron.core.regression.flux_regressor import (
     BowlFluxRegressor,
     PlaneFluxRegressor,
     NearestNeighborFluxRegressor,
+    Bracketing1DRegressor,
     BSplineRegressor,
     RBFRegressor,
     GridDataRegressor,
@@ -91,7 +92,7 @@ from pychron.pychron_constants import (
     GRIDDATA,
     IDW,
     HIGH_ORDER_POLY,
-    BRACKETING_1D
+    BRACKETING_1D,
 )
 
 HEADER_KEYS = [
@@ -260,7 +261,7 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
         options = self.plotter_options
         ipositions = self.unknown_positions + self.monitor_positions
 
-        if options.model_kind == LEAST_SQUARES_1D:
+        if options.model_kind in (LEAST_SQUARES_1D, WEIGHTED_MEAN_1D, BRACKETING_1D):
             k = options.one_d_axis.lower()
             pts = array([getattr(p, k) for p in ipositions])
         else:
@@ -269,6 +270,7 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
         if options.use_monte_carlo and options.model_kind not in (
             MATCHING,
             BRACKETING,
+            BRACKETING_1D,
             NN,
         ):
             fe = FluxEstimator(options.monte_carlo_ntrials, reg)
@@ -337,9 +339,8 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
             klass = WeightedMeanRegressor
         elif model_kind == BRACKETING_1D:
             xs = x if po.one_d_axis == "X" else y
-            klass = IDWRegressor
-            #kw["n"] = 2
-            #kw["interpolation_style"] = po.interpolation_style
+            klass = Bracketing1DRegressor
+            kw["one_d_axis"] = po.one_d_axis
         else:
             if model_kind == BOWL:
                 klass = BowlFluxRegressor
@@ -348,7 +349,7 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
             elif model_kind == MATCHING:
                 klass = NearestNeighborFluxRegressor
                 kw["n"] = 1
-            elif model_kind in (BRACKETING, BRACKETING_1D):
+            elif model_kind == BRACKETING:
                 klass = NearestNeighborFluxRegressor
                 kw["n"] = 2
                 kw["interpolation_style"] = po.interpolation_style
@@ -374,11 +375,9 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
         wf = po.use_weighted_fit
         ec = po.predicted_j_error_type
 
-        reg = klass(
-            xs=xs, ys=z, yserr=ze, error_calc_type=ec, use_weighted_fit=wf, **kw
-        )
+        reg = klass(xs=xs, ys=z, yserr=ze, error_calc_type=ec, use_weighted_fit=wf, **kw)
         reg.calculate()
-        if isinstance(reg, NearestNeighborFluxRegressor):
+        if hasattr(reg, "set_neighbors"):
             reg.set_neighbors(self.unknown_positions, self.monitor_positions)
         return reg
 
@@ -611,33 +610,37 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
     @property
     def cleaned_analyses(self):
         enabled_positions = [p.hole_id for p in self.monitor_positions if p.use]
-        vs = [
-            a
-            for a in zip(*self._analyses)
-            if a[0].irradiation_position in enabled_positions
-        ]
+        vs = [a for a in zip(*self._analyses) if a[0].irradiation_position in enabled_positions]
         return vs
 
     def _graph_linear_j(self, x, y, r, reg, refresh):
         g = self.graph
         if not isinstance(g, RegressionGraph):
-            g = RegressionGraph(
-                container_dict={"bgcolor": self.plotter_options.bgcolor}
-            )
+            g = RegressionGraph(container_dict={"bgcolor": self.plotter_options.bgcolor})
             self.graph = g
 
         po = self.plotter_options
         g.clear()
 
         plot = g.new_plot(padding=po.get_paddings())
+        bracketing = po.model_kind == BRACKETING_1D
         if po.model_kind == WEIGHTED_MEAN_1D:
             fit = "weighted mean"
-        elif po.model_kind == BRACKETING_1D:
+        elif bracketing:
+            # bracketing has no statsmodels fit; the line is drawn manually below
             fit = None
         else:
             fit = po.least_squares_fit
-        print("fit", fit)
-        _, scatter, line = g.new_series(x=reg.xs, y=reg.ys, yerror=reg.yserr, fit=fit)
+
+        result = g.new_series(x=reg.xs, y=reg.ys, yerror=reg.yserr, fit=fit)
+        # new_series returns (plot, scatter, line) when a fit is requested but
+        # only (scatter, plot) when fit is None (bracketing).
+        line = None
+        if len(result) == 3:
+            _, scatter, line = result
+        else:
+            scatter, _ = result
+
         ebo = ErrorBarOverlay(component=scatter, orientation="y")
         scatter.underlays.append(ebo)
         scatter.error_bars = ebo
@@ -649,17 +652,30 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
         g.set_x_title(po.one_d_axis)
         g.set_y_title("J")
 
-        g.add_statistics()
+        if not bracketing:
+            g.add_statistics()
 
         miy = 100
         may = -1
 
+        # draw the bracketing (piecewise-linear lever-rule) curve manually,
+        # spanning monitors and unknowns so the extrapolation tails are visible
+        line_ys = None
+        if bracketing:
+            ipositions = self.unknown_positions + self.monitor_positions
+            k = po.one_d_axis.lower()
+            fxs = array(sorted({getattr(p, k) for p in ipositions}))
+            line_ys = array(reg.predict(fxs))
+            lline, _ = g.new_series(fxs, line_ys, type="line")
+
+            # scatter the predicted unknown positions on the curve
+            if self.unknown_positions:
+                uxs = array([getattr(p, k) for p in self.unknown_positions])
+                uys = array([p.j for p in self.unknown_positions])
+                g.new_series(uxs, uys, type="scatter", marker="diamond", marker_size=4)
+
         if self._individual_analyses_enabled:
-            sel = [
-                i
-                for i, (a, x, y, e) in enumerate(self.cleaned_analyses)
-                if a.is_omitted()
-            ]
+            sel = [i for i, (a, x, y, e) in enumerate(self.cleaned_analyses) if a.is_omitted()]
 
             # plot the individual analyses
             iscatter, iys = self._graph_individual_analyses(fit=None, add_tools=False)
@@ -676,17 +692,18 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
 
         g.refresh()
 
-        fys = line.value.get_data()
+        if line is not None:
+            fys = line.value.get_data()
+        elif line_ys is not None:
+            fys = line_ys
+        else:
+            fys = reg.ys
         self.max_j = fys.max()
         self.min_j = fys.min()
 
     def _graph_hole_vs_j(self, x, y, r, reg, refresh):
         if self._individual_analyses_enabled:
-            sel = [
-                i
-                for i, (a, x, y, e) in enumerate(self.cleaned_analyses)
-                if a.is_omitted()
-            ]
+            sel = [i for i, (a, x, y, e) in enumerate(self.cleaned_analyses) if a.is_omitted()]
 
         g = self.graph
         if not isinstance(g, Graph):
@@ -749,9 +766,7 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
 
             if po.model_kind in (MATCHING, BRACKETING, NN):
                 yerror = reg.predict_error(pts)
-                p, _ = g.new_series(
-                    fxs, fys, yerror=yerror, render_style=render_style, type=kind
-                )
+                p, _ = g.new_series(fxs, fys, yerror=yerror, render_style=render_style, type=kind)
                 ebo = ErrorBarOverlay(component=p, orientation="y")
                 p.underlays.append(ebo)
                 p.error_bars = ebo
@@ -916,9 +931,7 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
                     add_axes_tools(g, plot)
                     yy = z[idx] * scale
                     ye = ze[idx] * scale
-                    plot.title = "Identifier={} Position={}".format(
-                        ip.identifier, ip.hole_id
-                    )
+                    plot.title = "Identifier={} Position={}".format(ip.identifier, ip.hole_id)
 
                     plot.x_axis.visible = False
                     if c == 0 and r == nrows // 2:
@@ -971,9 +984,7 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
                         marker_size=3,
                     )
                     g.set_x_limits(0, n - 1, pad="0.1", plotid=idx)
-                    g.set_y_limits(
-                        min(iys - ies), max(iys + ies), pad="0.1", plotid=idx
-                    )
+                    g.set_y_limits(min(iys - ies), max(iys + ies), pad="0.1", plotid=idx)
                     g.add_statistics(plotid=idx)
 
                     ebo = ErrorBarOverlay(component=s, orientation="y")
@@ -1153,9 +1164,7 @@ class FluxVisualizationEditor(BaseFluxVisualizationEditor):
             fx, fy, mx, my = self.model_plane(x, y, z, ze)
 
             x = arctan2(x, y)
-            plot = g.new_plot(
-                padding_left=100, padding_top=20, padding_right=10, padding_bottom=30
-            )
+            plot = g.new_plot(padding_left=100, padding_top=20, padding_right=10, padding_bottom=30)
 
             s = g.new_series(x, z, yerror=ze, type="scatter")[0]
             ebo = ErrorBarOverlay(component=s, orientation="y")
@@ -1233,9 +1242,7 @@ class FluxVisualizationEditor(BaseFluxVisualizationEditor):
         for idx in argwhere(split_idx):
             idx = idx[0]
 
-            yield sorted(
-                self.monitor_positions[pidx : idx + 1], key=lambda p: arctan2(p.x, p.y)
-            )
+            yield sorted(self.monitor_positions[pidx : idx + 1], key=lambda p: arctan2(p.x, p.y))
             pidx = idx + 1
 
         yield sorted(self.monitor_positions[pidx:], key=lambda p: arctan2(p.x, p.y))

--- a/pychron/pipeline/editors/flux_visualization_editor.py
+++ b/pychron/pipeline/editors/flux_visualization_editor.py
@@ -228,8 +228,8 @@ class BaseFluxVisualizationEditor(BaseTraitsEditor):
 
             x, y = t.transforms(x, y)
             # print(x)
-        except ValueError as e:
-            self.debug("no monitor positions to fit, {}".format(e))
+        except ValueError as err:
+            self.debug("no monitor positions to fit, {}".format(err))
             return
 
         # print(x)


### PR DESCRIPTION
## What

Adds a dedicated **1-D bracketing (lever-rule)** flux model and fixes the 2-D nearest-neighbor LINEAR interpolation it shares concepts with.

### `Bracketing1DRegressor` (new)
- Monitors projected onto the chosen 1-D axis (X/Y), sorted once in `calculate()`.
- Straddling monitor pair located via `searchsorted`; lever-rule value `j = y0 + f*(y1 - y0)`.
- Error propagated in **quadrature**: `sqrt(((1-f)·e0)² + (f·e1)²)`.
- **Linear extrapolation** past the monitor range (`f` left unclamped) — per design decision.
- Fills `bracket_a` / `bracket_b` on unknown positions.

### Wiring / bug fixes (`flux_visualization_editor.py`)
- `BRACKETING_1D` now builds `Bracketing1DRegressor`. It was **mis-wired to `IDWRegressor`** (a 2-D inverse-distance tree fed 1-D coordinates → wrong results); the correct branch was also unreachable dead code.
- `predict_values`: build 1-D `pts` for `BRACKETING_1D` / `WEIGHTED_MEAN_1D` (previously got 2-D points → shape mismatch against 1-D `xs`). Excluded from Monte Carlo.
- `_graph_linear_j`: removed a stray `print`; guarded the `new_series` 2- vs 3-tuple return so `fit=None` no longer crashes on `line.value.get_data()`. Draws the piecewise lever-rule curve plus predicted-unknown markers.
- `set_neighbors` dispatched via `hasattr` instead of an `isinstance` check tied to one class.

### `flux_views.py`
- Axis selector now shows for `BRACKETING_1D`.

### `NearestNeighborFluxRegressor` LINEAR fixes
- Replaced `linear_interp` (Euclidean distance) with `lever_fraction` (scalar projection): off-line unknowns now project correctly onto the monitor segment, and a point before the first monitor gets a negative fraction (was impossible with magnitude-only distance).
- Error now propagated in **quadrature** instead of being linearly interpolated (which underestimated it).

## Why

`BRACKETING_1D` was selectable in the GUI but non-functional — wrong regressor, wrong point shapes, and a guaranteed crash in the 1-D plot path. The 2-D `BRACKETING` (NN LINEAR) path silently produced wrong values for off-line unknowns and underestimated errors.

## Reviewer notes

- "Interpolate" and "lever-rule" are the same math, exposed as the single `BRACKETING_1D` model kind (the `interpolation_style` knob remains for 2-D `BRACKETING` only).
- `linear_interp` removed; its only live caller was the NN LINEAR branch (the `flux_results_editor` references are commented-out dead code).
- Black normalized one adjacent unicode escape (`λ` → `λ`) in `flux_views.py` — cosmetic, black-compliant.

## Testing

- New `Bracketing1DRegressionTest` (8): midpoint/quarter interpolation, quadrature error, exact-on-node, below/above extrapolation, unsorted input, `set_neighbors`.
- New `NearestNeighborLinearTest` (3): midpoint value, quadrature error, off-line projection.
- Full regression suite **46/46 passing**; `black --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
