### PR TITLE
docs(ai): add Ar/Ar geochronology and noble-gas mass-spec domain primers for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ editing the science or instrument layers (`pychron/processing`,
 - `docs/ai/noble_gas_mass_spectrometer.md` — the instrument that measures the
   isotopes: ion source/acceleration voltage, magnet/MFTABLE mass dispersion,
   detectors/gain/deflection, resolution, peak centering, and tuning scans.
+- `docs/ai/extraction_and_uhv.md` — the UHV front end that releases and delivers
+  the gas: valves/interlocks, vacuum gauges/pumps, furnaces and laser extraction
+  devices, and PID temperature control.
 
 Repo Map
 ========

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,23 @@ Pychron is a long-lived scientific application with mixed concerns:
 
 Favor conservative, low-regression changes over broad rewrites.
 
+Domain Context
+==============
+
+Pychron is an **⁴⁰Ar/³⁹Ar geochronology** application: it runs a noble-gas mass
+spectrometry lab and reduces argon-isotope data into geologic ages. Before
+editing the science or instrument layers (`pychron/processing`,
+`pychron/pipeline`, `pychron/experiment`, `pychron/spectrometer`,
+`pychron/dvc`), read the relevant domain primer first. Use them to understand
+*why* a function exists, not just what it does:
+
+- `docs/ai/arar_geochronology.md` — the lab workflow and the
+  isotope-correction → F → J → age math, with a glossary mapping geochronology
+  terms to the code that implements them.
+- `docs/ai/noble_gas_mass_spectrometer.md` — the instrument that measures the
+  isotopes: ion source/acceleration voltage, magnet/MFTABLE mass dispersion,
+  detectors/gain/deflection, resolution, peak centering, and tuning scans.
+
 Repo Map
 ========
 

--- a/docs/ai/arar_geochronology.md
+++ b/docs/ai/arar_geochronology.md
@@ -1,0 +1,301 @@
+# Ar/Ar Geochronology — Domain Primer for Agents
+
+This document explains the *science* Pychron exists to do, so that an agent
+editing the code understands **why** a function, method, or workflow exists, not
+just what it mechanically does. The other files in `docs/ai/` map code
+structure; this one maps the geochronology.
+
+If you are touching `pychron/processing`, `pychron/pipeline`,
+`pychron/experiment`, `pychron/spectrometer`, or `pychron/dvc`, read this first.
+For the instrument that produces the isotope data, see the companion primer
+`docs/ai/noble_gas_mass_spectrometer.md`.
+
+---
+
+## 1. What Pychron is for
+
+Pychron runs an **⁴⁰Ar/³⁹Ar geochronology laboratory** and reduces the data it
+produces into **ages** (how long ago a rock/mineral cooled or formed) with
+rigorous uncertainties. It spans the whole chain: controlling the mass
+spectrometer and extraction hardware, automating the measurement sequence,
+persisting raw data, and computing ages from that data.
+
+The ⁴⁰Ar/³⁹Ar method is a variant of K–Ar dating. Potassium-40 (⁴⁰K) decays to
+argon-40 (⁴⁰Ar) with a known half-life. Measure how much radiogenic ⁴⁰Ar a
+sample has accumulated relative to its potassium, and you get an age. The trick
+of the Ar/Ar method: instead of measuring K directly, you irradiate the sample
+with neutrons to convert ³⁹K → ³⁹Ar, so a *single* noble-gas mass spectrometer
+measurement of argon isotopes gives you both the parent proxy (³⁹Ar) and the
+daughter (⁴⁰Ar).
+
+---
+
+## 2. The lab workflow (and where each stage lives)
+
+```
+ sample → irradiation → extraction → mass-spec measurement → data reduction → interpretation
+```
+
+| Stage | What happens physically | Where in code |
+|-------|------------------------|---------------|
+| **Irradiation** | Sample + flux monitors loaded in trays, sent to a reactor. Neutrons convert ³⁹K→³⁹Ar (and produce interfering isotopes from Ca, Cl, K). | `pychron/entry` (irradiation/level/position entry), `pychron/processing` flux handling |
+| **Extraction** | Gas released from a sample by laser or furnace heating, in one step (fusion) or many (incremental/step heating). Gas is cleaned (getters) of non-noble gases. | `pychron/lasers`, `pychron/furnace`, `pychron/extraction_line`, scripted by `pychron/pyscripts` |
+| **Measurement** | Cleaned argon admitted to the mass spectrometer; ion beams for masses 40,39,38,37,36 measured on detectors (Faraday cups and/or ion counters/CDD). | `pychron/spectrometer`, orchestrated by `pychron/experiment` |
+| **Reduction** | Raw intensities corrected and combined into an age. (Section 4.) | `pychron/processing`, `pychron/pipeline` |
+| **Persistence** | Raw + reduced data versioned in git-backed repositories. | `pychron/dvc` |
+| **Interpretation** | Plateaus, isochrons, weighted means; final "interpreted age" per sample. | `pychron/processing/plateau.py`, `argon_calculations.py`, `interpreted_age.py`, `pychron/pipeline` |
+
+An **experiment** is an automated queue of **runs**. Each run is one
+extraction+measurement of one position (an unknown sample, a flux monitor, a
+blank, an air shot, or a cocktail standard).
+
+---
+
+## 3. The measurement model (raw intensities → corrected isotopes)
+
+Five argon isotopes are the core observables. Constant keys in
+`pychron/pychron_constants.py`:
+
+```python
+ARGON_KEYS = (AR40, AR39, AR38, AR37, AR36)   # "Ar40".."Ar36"
+```
+
+| Isotope | Primary meaning in Ar/Ar |
+|---------|--------------------------|
+| **⁴⁰Ar** | radiogenic (from ⁴⁰K decay) + atmospheric + K-interference |
+| **³⁹Ar** | proxy for K (from ³⁹K via irradiation) — the "parent" signal |
+| **³⁸Ar** | Cl-derived + atmospheric + cosmogenic |
+| **³⁷Ar** | proxy for Ca (from ⁴⁰Ca via irradiation); short-lived, decays |
+| **³⁶Ar** | atmospheric + Ca-interference + cosmogenic — the "trapped" tracer |
+
+Before any age math, each measured intensity is corrected for instrument and
+procedural effects (see `calculate_f` docstring in `argon_calculations.py`):
+
+- **Baseline** — detector signal with no beam (electronic zero).
+- **Blank** — argon contributed by the extraction/measurement system itself,
+  not the sample. Measured on blank runs, subtracted from unknowns.
+- **IC factor** (inter-calibration / detector intercalibration) — relative gain
+  between detectors, so ion-counter and Faraday signals are comparable.
+- **Discrimination / mass fractionation** — the spectrometer favors some masses
+  over others; calibrated against air shots (known atmospheric ⁴⁰/³⁶ ≈ 295.5).
+- **Ar37/Ar39 decay** — ³⁷Ar (≈35 d half-life) and ³⁹Ar decay measurably
+  between irradiation and analysis; corrected back to irradiation time.
+
+Per-isotope correction logic lives in `pychron/processing/isotope.py` and
+`arar_age.py`. By the time intensities reach `calculate_f`, they are assumed
+**already** blank/baseline/IC/discrimination/decay corrected.
+
+### Time zero — the intensity-vs-time intercept
+
+A single isotope is not measured as one number. The detector records a **time
+series** of intensity during the few minutes the gas is in the analyzer
+(`Isotope.xs`/`ys` in `isotope.py`). In static vacuum the signal changes over
+that window — radiogenic peaks decay as gas is consumed/pumped, blanks grow —
+so the physically meaningful value is the signal **at the moment the gas was
+admitted**: *time zero*.
+
+Pychron fits a regression (linear/parabolic/exponential/mean per the chosen
+fit) to the series and extrapolates to t=0:
+
+- `Isotope.offset_xs = xs − time_zero_offset` shifts the clock so t=0 is the
+  inlet time; `set_time_zero()` sets the offset.
+- `_predict_at_t_zero()` runs the regressor and returns
+  `(reg.predict(0), reg.predict_error(0))` as one `ufloat`, cached so every
+  access shares the same correlation node.
+- That intercept value/error is what feeds blank/baseline/IC correction and
+  ultimately `calculate_f`.
+
+The choice of fit type and time-zero offset directly changes the reported
+intensity, hence the age. This is intentional extrapolation, not curve-cleaning.
+
+---
+
+## 4. The reduction math (corrected isotopes → age)
+
+This is the scientific heart of the codebase:
+`pychron/processing/argon_calculations.py`. The pipeline, in order:
+
+1. **Interference corrections** — `interference_corrections()`
+   Neutron irradiation produces argon not just from K but also from Ca, Cl, and
+   K itself, using reactor-specific **production ratios** (e.g. `Ca3937`,
+   `K3739`, `Ca3637`, `K4039`). This step partitions the measured ³⁹/³⁷/³⁸/³⁶
+   into K-derived, Ca-derived, etc. `K3739` may be solved normally or fixed
+   (`apply_fixed_k3739`).
+
+2. **Atmospheric correction** — `calculate_atmospheric()`
+   Separates atmospheric (trapped) argon and Cl-derived argon from ³⁶/³⁸ using
+   the air ³⁸/³⁶ ratio and ³⁶Cl decay (McDougall & Harrison; Roddick 1983;
+   Foland 1993). Yields `atm36`, `cl36`, etc.
+
+3. **Cosmogenic correction** (optional) — `calculate_cosmogenic_components()`
+   Two-component mixing to remove cosmic-ray-produced ³⁶/³⁸ in old/exposed
+   samples.
+
+4. **F = ⁴⁰Ar\*/³⁹Ar_K** — `calculate_f()`
+   `rad40 = a40 − atm40 − k40`, then `F = rad40 / k39`. `F` (a.k.a. `F`/`Far`)
+   is the radiogenic-⁴⁰/³⁹_K ratio — the age-bearing quantity. The function
+   also returns `f_wo_irrad` (F with irradiation-ratio errors zeroed, for error
+   budgeting) and `radiogenic_yield` (% radiogenic ⁴⁰Ar).
+
+5. **Age** — `age_equation()`
+   ```
+   age = (1/λ_total) · ln(1 + J·F)
+   ```
+   `J` is the **irradiation parameter** (the neutron-fluence calibration, see
+   §6). `λ_total` is the total ⁴⁰K decay constant. Age comes out in years and is
+   scaled to the configured units (`scale_age`).
+
+Supporting calculations:
+- `calculate_flux()` — inverts the age equation to solve for `J` from a flux
+  monitor of known age.
+- `convert_age()` / `age_converter.py` — recompute legacy ages onto new monitor
+  ages or decay constants.
+- Plateau, isochron, ideogram, and error propagation are covered in §5.
+
+---
+
+## 5. Interpretation & statistics (many runs → one age)
+
+A single run gives one F/age. Real results combine many steps (step-heating) or
+many aliquots (single-fusion) into one defensible age with uncertainty. The
+combining methods live in `pychron/processing` (math) and
+`pychron/pipeline/plot/plotter` (figures).
+
+### Isochron — `argon_calculations.py`
+
+`calculate_isochron()` / `get_isochron_regressors()`. The **inverse isochron**
+plots ³⁶Ar/⁴⁰Ar (y) vs ³⁹Ar/⁴⁰Ar (x) across steps/aliquots:
+
+- The **x-intercept** relates to age (`r = 1/regx.intercept`, fed to
+  `age_equation`); the **y-intercept** gives the trapped ⁴⁰Ar/³⁶Ar.
+- Unlike a plateau, the isochron **solves for the trapped composition** instead
+  of assuming air (295.5), so it detects/handles excess or non-atmospheric
+  trapped argon.
+- Regression is error-weighted in both axes (correlated x/y errors): York-type
+  fits in `pychron/core/regression/new_york_regressor.py` —
+  `NewYorkRegressor` (default), `YorkRegressor`, `ReedYorkRegressor`. Selected
+  by the `reg=` argument.
+- `include_j_err` toggles whether J uncertainty enters the isochron age.
+
+### Plateau — `argon_calculations.py` + `plateau.py`
+
+`calculate_plateau_age()` builds a `Plateau` over the **age spectrum** (age vs
+cumulative ³⁹Ar released, step by step). A valid plateau is a run of contiguous
+steps that:
+
+- agree within error (`overlap_sigma`, default 2σ; method `FLECK` etc.),
+- span ≥ a minimum number of steps (`nsteps`, default 3), and
+- release ≥ a minimum gas fraction (`gas_fraction`, default 50% of ³⁹Ar).
+
+`find_plateaus(method)` locates the qualifying steps (or `fixed_steps` forces
+them); the plateau age is the **weighted mean** of those steps —
+inverse-variance by default, or ³⁹ArK-volume-weighted (`kind="vol_fraction"`).
+A flat plateau implies the sample behaved as a closed system; a disturbed
+spectrum (rising/saddle) signals argon loss or excess argon.
+
+### Ideogram — `pychron/pipeline/plot/plotter/ideogram.py`
+
+A probability-density figure of a population of ages (`Ideogram(BaseArArFigure)`).
+Each age is a Gaussian (center = age, width = its error); summing them shows
+where ages cluster:
+
+- `cumulative_probability` (sum of Gaussians) and `kernel_density` (KDE) from
+  `pychron/core/stats/probability_curves.py` build the curve
+  (`_plot_relative_probability`).
+- Used to judge whether a sample is a single age population or a mix
+  (multiple peaks), and to read a weighted-mean/mode age for the group.
+- Distinct from the age **spectrum** (plateau): an ideogram ignores gas
+  fraction and step order; it is purely about the distribution of ages.
+
+### Error propagation
+
+Pychron carries uncertainties two complementary ways:
+
+- **Automatic** — the `uncertainties` package (`ufloat`) propagates errors and
+  inter-variable **correlations** through every operation. Preserve `tag=`
+  arguments: they label error components so `error_contrib.py` can report each
+  source's contribution to the final age error. Stripping a value to
+  `nominal_value` mid-chain silently drops its error and its correlations.
+- **Analytic** — closed-form formulas where they matter, e.g.
+  `calculate_error_F` and `calculate_error_t` (McDougall & Harrison eq. 3.43)
+  for the F and age errors.
+
+`error_calc_kind` / `error_type` select how regression and mean errors are
+computed (e.g. SE vs SD, MSWD-scaled). **MSWD** (mean square weighted deviation)
+gauges scatter vs analytical error: ≈1 means errors explain the scatter; ≫1
+means geological scatter and the reported error is inflated accordingly.
+
+---
+
+## 6. Key concepts → glossary
+
+- **J / J-value (irradiation parameter)** — converts measured ⁴⁰Ar\*/³⁹Ar_K (F)
+  into age. Determined by co-irradiating **flux monitors** (mineral standards of
+  independently-known age, e.g. Fish Canyon sanidine) and solving the age
+  equation for J. Each sample's J is interpolated from monitors around it.
+  See `calculate_flux`, `pychron/processing/flux.py`, `j_error_mixin.py`.
+- **Flux monitor / standard** — a sample of known age used to measure neutron
+  fluence (J). "Unknowns" are the samples whose ages you actually want.
+- **F (Far)** — radiogenic ⁴⁰Ar\* / ³⁹Ar_K. The age-bearing ratio.
+- **Radiogenic ⁴⁰Ar (rad40 / ⁴⁰Ar\*)** — the ⁴⁰Ar from in-situ ⁴⁰K decay, after
+  removing atmospheric and interference ⁴⁰Ar.
+- **Trapped / atmospheric argon** — non-radiogenic ⁴⁰Ar; assumed air-like
+  (⁴⁰/³⁶ ≈ 295.5) unless an isochron says otherwise.
+- **Production ratios / interference corrections** — reactor-specific factors
+  (`Ca3937`, `K3739`, `Ca3637`, `Ca3837`, `K4039`, `K3839`, `Cl3638`) describing
+  unwanted argon made during irradiation.
+- **Plateau** — in step-heating, a run of consecutive steps with concordant ages
+  releasing a large fraction of the ³⁹Ar; their weighted mean is the plateau age
+  (§5).
+- **Isochron** — regression across steps/aliquots that solves for age *and*
+  trapped composition simultaneously (§5).
+- **Ideogram** — probability-density plot of an age population; reveals single vs
+  mixed populations (§5).
+- **MSWD** — mean square weighted deviation; scatter relative to analytical
+  error (≈1 good, ≫1 = geological scatter).
+- **Step heating vs total fusion** — incremental temperature steps (resolves age
+  spectra/disturbance) vs a single melt (one bulk age).
+- **Blank / baseline / air shot / cocktail** — procedural runs: system
+  background, detector zero, atmospheric-ratio calibration, multi-element check.
+- **KCa / KCl** — K/Ca and K/Cl ratios derived from ³⁹/³⁷ and ³⁸/³⁹; chemical
+  fingerprints reported alongside age (`_calculate_kca`, `_calculate_kcl`).
+- **MDD** — multiple-diffusion-domain thermal modeling (`pychron/mdd`); thermal
+  history from age spectra.
+- **Interpreted age** — the lab's final adopted age for a sample (plateau,
+  isochron, weighted mean, or integrated), `interpreted_age.py`.
+
+---
+
+## 7. Constants reference
+
+Decay/physical constants — `pychron/processing/arar_constants.py` (`ArArConstants`):
+
+- `lambda_e` — ⁴⁰K electron-capture branch → ⁴⁰Ar (the geochronologically useful
+  branch). Default `5.81e-11 /yr`.
+- `lambda_b` — ⁴⁰K beta branch → ⁴⁰Ca. Default `4.962e-10 /yr`.
+- `lambda_k` — total ⁴⁰K decay constant (`λ_e + λ_b`), used in the age equation.
+- `lambda_Ar37`, `lambda_Ar39`, `lambda_Cl36` — decay of the irradiation-produced
+  short-lived isotopes.
+- `atm4036` (≈ 295.5, Nier 1950) and `atm3836` — atmospheric argon ratios.
+- `solar3836`, `cosmo3836` — end-member ³⁸/³⁶ for cosmogenic correction.
+
+`FLUX_CONSTANTS` and `K_DECAY_CONSTANTS` in `pychron/pychron_constants.py` hold
+named decay-constant sets (e.g. Min 2008, Steiger & Jäger 1977). Different labs
+and papers adopt different constants; **never silently change a default** — the
+choice changes every reported age. Citation fields (`*_citation`) record the
+source.
+
+---
+
+## 8. Pitfalls for an editing agent
+
+- Ages and ratios carry uncertainties via `ufloat`; don't strip `nominal_value`
+  off a value that feeds an error budget, and preserve `tag=`.
+- The correction order in §4 is not arbitrary — interference before atmospheric
+  before cosmogenic before F. Reordering changes results.
+- Decay constants, monitor ages, and production ratios are *configuration*, not
+  code constants; defaults exist but real runs load them per-irradiation/lab.
+- `f_wo_irrad`, `*_wo_*` variants exist to isolate error sources — they are not
+  redundant copies.
+- Negative corrected quantities can be physically meaningless but statistically
+  valid; respect flags like `allow_negative_ca_correction`.

--- a/docs/ai/arar_geochronology.md
+++ b/docs/ai/arar_geochronology.md
@@ -8,7 +8,8 @@ structure; this one maps the geochronology.
 If you are touching `pychron/processing`, `pychron/pipeline`,
 `pychron/experiment`, `pychron/spectrometer`, or `pychron/dvc`, read this first.
 For the instrument that produces the isotope data, see the companion primer
-`docs/ai/noble_gas_mass_spectrometer.md`.
+`docs/ai/noble_gas_mass_spectrometer.md`; for the UHV line that extracts and
+delivers the gas, see `docs/ai/extraction_and_uhv.md`.
 
 ---
 

--- a/docs/ai/extraction_and_uhv.md
+++ b/docs/ai/extraction_and_uhv.md
@@ -1,0 +1,172 @@
+# Gas Extraction & UHV System — Domain Primer for Agents
+
+Third companion to `docs/ai/arar_geochronology.md` (the science) and
+`docs/ai/noble_gas_mass_spectrometer.md` (the detector). This one covers the
+**front end**: the ultra-high-vacuum (UHV) gas-handling line that releases argon
+from a sample, cleans it, and delivers a known aliquot to the spectrometer.
+
+Read it before editing `pychron/extraction_line`, `pychron/furnace`,
+`pychron/lasers`, or the vacuum/heater/laser device classes under
+`pychron/hardware`. It explains *why* valves, gauges, PID controllers, and laser
+managers exist and how they map to the code.
+
+---
+
+## 1. Why a UHV extraction line exists
+
+Argon abundances in a sample are minuscule, and the **atmosphere is ~1% argon**.
+A single air leak swamps the signal. So the entire gas path is held at
+ultra-high vacuum (≲1e-8 torr) and the sample gas is isolated, heated, purified,
+and measured without ever touching air. The extraction line is the plumbing that
+does this: a manifold of chambers connected by **valves**, monitored by
+**gauges**, evacuated by **pumps**, with sample heated by a **furnace** or
+**laser**.
+
+The package owns exactly this. From `pychron/extraction_line/README.md`:
+pneumatic valves, vacuum gauges, cryo/heaters, pumps, manometers, pipette
+tracking, sample changer, a 2D canvas of live valve state, and a graph topology
+for volume/path calculations.
+
+A typical run sequence: isolate a clean section → admit sample gas → heat
+(extract) → expose to **getters** (chemically absorb non-noble gases) → let
+argon equilibrate → admit to the spectrometer → measure → pump away.
+
+---
+
+## 2. Valves / switches — the plumbing
+
+`pychron/extraction_line/switch_manager.py` (engine),
+`pychron/hardware/valve.py` (`HardwareValve`), `section.py` (groups).
+
+Valves are mostly **pneumatic**: a solenoid admits compressed air to open/close
+the valve; the controller may read back an indicator of actual position.
+
+| Concept | Code | Meaning |
+|---------|------|---------|
+| State | `HardwareValve.state` (True=open) | open/closed; persisted across restarts |
+| Software lock | `software_lock` | block actuation in software even if hardware could move |
+| Interlock | `SwitchManager` interlock checks | refuse to open a valve if a conflicting valve is open (prevents venting UHV to atmosphere) |
+| Ownership | manager ownership/`StatusMonitor` | in multi-client setups, who is allowed to actuate |
+| Double actuation | `DoubleActuationValve` | separate open/close channels + delays |
+| State word | `ClientSwitchManager` | remote reads a packed bitfield of all valve states |
+
+`ExtractionLineGraph` (`graph/extraction_line_graph.py`) models the line as
+nodes (valves, pumps, chambers) and edges; `traverse.py` does BFS that **stops
+at closed valves**, so the system can compute which chambers are connected, the
+total expansion volume, and whether a path to a pump or the spectrometer is open.
+This volume/topology matters scientifically: it sets gas expansion ratios and
+guards against accidentally opening the sample to a pump.
+
+---
+
+## 3. Vacuum gauges & pumps — measuring and maintaining UHV
+
+`pychron/extraction_line/gauge_manager.py`, `manometer_manager.py`,
+`pump_manager.py`, gauge drivers under `pychron/hardware/gauges/`.
+
+- **Ion gauge** (hot/cold cathode) — measures UHV pressure (≲1e-3 torr down to
+  ~1e-10). Vendors: `granville_phillips`, `mks`, `pfeiffer`, `varian`,
+  `igc100_gauge_controller.py`. Base: `gauges/base_controller.py`,
+  `base_gauge.py`; reads a `pressure`.
+- **Convection / Pirani gauge** — rough-to-medium vacuum (atmosphere down to
+  ~1e-3 torr); used during pump-down.
+- **Manometer** (`manometer_manager.py`) — capacitance/absolute pressure, e.g.
+  for measured gas aliquots.
+- **Pumps** (`pump_manager.py`, `pychron/hardware/ionpump`) — ion pumps and
+  turbo pumps maintain the vacuum; their current/pressure is also a vacuum
+  health proxy.
+
+Pressure readings gate the workflow: don't admit sample to the spectrometer, or
+fire the laser, unless vacuum is good. `status_monitor.py` polls hardware in a
+background thread so multiple clients see live state.
+
+---
+
+## 4. Furnaces & PID temperature control — bulk heating
+
+`pychron/furnace`, `pychron/hardware/pid_controller.py`,
+`pychron/hardware/eurotherm/`.
+
+A resistance furnace heats a sample (often in a metal crucible) to release gas,
+in **incremental temperature steps** (the step-heating that yields age spectra,
+see arar primer §5) or to a single high temperature (total fusion).
+
+Temperature is held by a **PID controller** — a closed feedback loop that drives
+heater output so the measured temperature tracks a target:
+
+- **Setpoint** — the target temperature you command (`set_setpoint`).
+- **Process value** — the measured temperature (`get_process_value`).
+- **Output** — % power the loop applies to the heater (`get_output`).
+- **PID gains** Kp/Ki/Kd — proportional/integral/derivative terms; `set_pid`
+  tunes how aggressively/stably the loop converges (`IFurnaceController` in
+  `furnace/ifurnace_controller.py`).
+
+Hardware backends: `PidController` wraps a **Eurotherm** controller
+(`pychron/hardware/eurotherm/`); vendor furnaces live in `furnace/nmgrl`,
+`furnace/thermo`, `furnace/ldeo`, `furnace/reston`.
+`configure_dump.py` handles dropping the sample into the hot furnace
+(sample-drop/dump mechanism). Bad PID tuning = temperature overshoot/oscillation
+= wrong gas-release temperature = a smeared age spectrum.
+
+---
+
+## 5. Laser extraction devices — spot/step heating
+
+`pychron/lasers/laser_managers/`. A laser heats a small spot (single grain or a
+sub-region of a sample), enabling spatially-resolved dating and fast fusion.
+Manager hierarchy: `BaseLaserManager` → `LaserManager` → device-specific.
+
+Laser types and managers:
+- **CO₂** (10.6 µm, bulk silicate heating) — `fusions_co2_manager.py`,
+  `synrad_co2_manager.py`, `uc2000_laser_manager.py`.
+- **Diode** (continuous, temperature-controlled heating) —
+  `fusions_diode_manager.py`.
+- **UV / excimer** (ablation, micro-sampling) — `fusions_uv_manager.py`,
+  `ablation_laser_manager.py`, `uv_gas_handler_manager.py`.
+
+Two control modes (`laser_manager.py`):
+- **Power / open loop** — `set_laser_power(power)` sets % output directly.
+  `enable_laser()` / `disable_laser()` arm/disarm; `emergency_shutoff` for
+  safety.
+- **Temperature / closed loop** — `WatlowMixin` /
+  `TemperatureControllerLaserMixin` (`watlow_mixin.py`) run a **PID loop on a
+  measured temperature** (`set_laser_temperature`, `set_{mode}_loop_setpoint`,
+  `set_pid`), with the temperature read by a **pyrometer**
+  (`pyrometer_mixin.py`). This is the same setpoint/process-value/output PID
+  concept as the furnace (§4), applied to laser output.
+
+Supporting: `stage_managers/` (XY/Z sample positioning), `pattern/` and
+`points/` (raster/scan patterns over a sample), `power/` (power calibration,
+mapping requested → actual watts).
+
+---
+
+## 6. Where this feeds the rest of Pychron
+
+- Extraction + measurement are **scripted** per run by `pychron/pyscripts`
+  (extraction script controls valves/laser/furnace; measurement script controls
+  the spectrometer) and sequenced by `pychron/experiment`.
+- The gas this system delivers is what the spectrometer measures
+  (`noble_gas_mass_spectrometer.md`) and what the reduction math turns into an
+  age (`arar_geochronology.md`).
+- **Blanks** (arar primer §3) are the argon this line contributes on its own —
+  which is why line cleanliness, getter health, and vacuum quality directly
+  affect data quality.
+
+---
+
+## 7. Pitfalls for an editing agent
+
+- **Interlocks and software locks are safety, not UI niceties.** Don't bypass
+  valve interlock checks; opening the wrong valve can vent UHV or destroy a
+  filament/ion gauge.
+- `ExtractionLineGraph` traversal **stops at closed valves** by design — that is
+  how connectivity/volume is computed; don't "fix" it to cross closed valves.
+- Client vs server managers (`Client*` classes) read state remotely via state
+  words; keep the two paths in sync when changing valve state handling.
+- Furnace and laser-diode both use **PID** with the same setpoint/process-value/
+  output/Kp-Ki-Kd vocabulary — don't assume "laser" means open-loop power only.
+- `enable_laser`/`disable_laser` and `emergency_shutoff` are safety-critical;
+  preserve disable-on-error paths.
+- Pressure/temperature readbacks gate downstream actions; don't remove the vacuum
+  checks that guard spectrometer inlet or laser firing.

--- a/docs/ai/noble_gas_mass_spectrometer.md
+++ b/docs/ai/noble_gas_mass_spectrometer.md
@@ -1,0 +1,184 @@
+# Noble-Gas Mass Spectrometer — Domain Primer for Agents
+
+Companion to `docs/ai/arar_geochronology.md`. That doc covers the *science*
+(turning argon isotopes into ages); this one covers the *instrument* that
+measures those isotopes. Read it before editing `pychron/spectrometer`,
+`pychron/spectrometer/ion_optics`, `pychron/spectrometer/jobs`, or detector/
+magnet/source device code — it explains *why* parameters like resolution,
+sensitivity, peak center, deflection, and acceleration voltage exist and how
+they map to the code.
+
+---
+
+## 1. What the instrument is
+
+A noble-gas mass spectrometer measures the abundance of each argon isotope
+(masses 40, 39, 38, 37, 36) in a tiny purified gas sample. These are
+**static-vacuum sector** instruments: the gas is trapped in a sealed analyzer
+(no continuous pumping during measurement) so vanishingly small noble-gas
+signals can be integrated over time.
+
+Physical path of an ion:
+
+```
+ gas → ion SOURCE (ionize + accelerate + focus) → flight tube
+     → MAGNET (mass disperse by m/z) → DETECTOR (collect ion current)
+```
+
+Supported vendor backends live in sibling packages, each with `source/`,
+`magnet/`, `detector/`, `spectrometer/`, `manager/`:
+`pychron/spectrometer/thermo` (Thermo: Argus, Helix, MAT253),
+`pychron/spectrometer/isotopx` (NGX), `pychron/spectrometer/pfeiffer`.
+Vendor-neutral base classes: `base_spectrometer.py`, `base_source.py`,
+`base_magnet.py`, `base_detector.py`.
+
+---
+
+## 2. The ion source — making and shaping the beam
+
+Electrons from a filament ionize neutral argon; electrostatic optics extract,
+accelerate, and focus the ions into a beam. Source parameters
+(`base_source.py`, `thermo/source/base.py`, `helix.py`) are tuned to maximize
+**sensitivity** (ions delivered to the detector per atom in the source) and
+**beam shape** (flat-topped, symmetric peaks):
+
+| Parameter (trait) | Physical meaning |
+|-------------------|------------------|
+| `nominal_hv` / `set_hv` / `read_hv` | **Acceleration (high) voltage** (~kV). Accelerates ions to a fixed kinetic energy. Defines the m/z↔magnet-field relationship; an HV scan can center a peak instead of moving the magnet (`AccelVoltagePeakCenter`, `hv_sweep.py`). |
+| `trap_current` | Filament emission regulator → controls electron flux that does the ionizing. More trap current ≈ more ionization ≈ more sensitivity (until saturation). |
+| `trap_voltage` | Potential confining electrons in the ionization region. |
+| `emission` | Readback of actual electron emission current — a health/sensitivity indicator. |
+| `extraction_lens` | Pulls ions out of the ionization volume into the optics. |
+| `y_symmetry`, `z_symmetry` | Steer/center the beam transverse to flight (peak shape, flat top). |
+| `vertical_deflection_n/s`, `flatapole`, `rotation_quad` (Helix) | Higher-order ion-optics: deflect/rotate/shape the beam for multi-collector alignment. |
+| `electron_energy` (vendor) | Filament electron energy; affects ionization efficiency and fragmentation of interfering species. |
+
+**Sensitivity** = signal per unit gas (e.g. A/mol, or cps/fA per atom). It sets
+the smallest sample datable and drifts as the source ages; tracked and used to
+normalize signals.
+
+---
+
+## 3. The magnet — separating masses
+
+A sector magnet bends ions on a radius set by mass, charge, velocity, and field
+strength. At fixed HV, **field ∝ √(m/z)**, so scanning the field (via a DAC
+voltage) sweeps different masses across a detector.
+
+`base_magnet.py` core API:
+- `dac` — the DAC voltage (0–10 V) that commands magnet field.
+- `mass` — the mass currently centered on the reference detector.
+- `map_mass_to_dac(mass, detname)` / `map_dac_to_mass(dac, detname)` — convert
+  between amu and DAC **per detector**, because each collector sits at a
+  different physical position.
+
+These mappings come from the **MFTABLE** (magnet field table): a per-detector
+calibration of DAC↔mass, built/maintained by `mftable_generator.py`,
+`auto_mftable.py`, `field_table.py`, `mass_cal/mass_calibrator.py`. Editing
+magnet code without respecting the MFTABLE will mis-position every peak.
+
+---
+
+## 4. The detectors — collecting ion current
+
+`base_detector.py`. Two collector types (`kind`):
+
+- **Faraday cup** — measures beam current as a voltage across a large resistor.
+  Robust, linear, for big beams (e.g. ⁴⁰Ar, ³⁹Ar).
+- **Ion counter / CDD** (electron multiplier / "compact discrete dynode") —
+  counts individual ions; ultra-sensitive, for tiny beams (e.g. ³⁶Ar). Has an
+  operating high voltage tuned via `cdd_operating_voltage_scan.py`.
+
+Detector concerns in code:
+- `gain` / `software_gain` — amplification factor; relative gains are why an
+  **IC factor** (inter-calibration) is needed (see arar primer §3) so different
+  detectors are comparable.
+- `deflection` / `use_deflection` / `deflection_correction_sign` — small per-cup
+  electrostatic steering so each collector sits exactly on its peak;
+  calibrated by `thermo/deflection.py` (`DeflectionCalibration`).
+- `protection_threshold` — guards a sensitive ion counter from large beams.
+- A multicollector measures several masses simultaneously on an array of cups;
+  a single-collector ("peak hopping") instrument steps the magnet to each mass
+  in turn.
+
+---
+
+## 5. Resolution & resolving power
+
+**Resolution** describes how well two adjacent masses are separated, i.e. how
+sharp the peak edges are. In a sector instrument it is set by source/collector
+slit widths and beam focus.
+
+Pychron computes it from a peak-center scan (`pychron/core/stats/peak_detection.py`):
+
+- `calculate_resolution(x, y)` → `res = cx / (hx − lx)` — center DAC divided by
+  the peak width at 95% of max. Higher = sharper peak.
+- `calculate_resolving_power(x, y)` — measured from the low- and high-mass
+  edges between 5% and 95% of peak height; reports the rising/falling-edge
+  resolving power separately.
+
+Why it matters scientifically: ⁴⁰Ar from ³⁶Ar / hydrocarbon / doubly-charged
+interferences must be resolved or accounted for. Low resolution = peaks overlap
+= biased isotope ratios = wrong ages.
+
+---
+
+## 6. Peak centering
+
+`pychron/spectrometer/ion_optics/`, `pychron/spectrometer/jobs/peak_center.py`.
+
+A **peak center** finds the magnet DAC (or HV) at which an isotope's beam sits
+squarely on a detector, so the measurement integrates the flat top of the peak
+rather than a sloping flank (where tiny field drift would change the signal).
+
+- `BasePeakCenter.get_peak_center()` sweeps the magnet across a reference mass,
+  records intensity vs DAC, and locates the center.
+- `PeakCenter(MagnetSweep)` moves the magnet; `AccelVoltagePeakCenter(AccelVoltageSweep)`
+  moves HV instead.
+- `_calculate_peak_center` → `calculate_peak_center` / `calculate_peak_center_pseudo`
+  in `peak_detection.py` return `[low, center, high]` DAC positions; `PeakCenterResult`
+  also carries `resolution`.
+- Config/UI: `peak_center_config.py`, `define_peak_center_view.py`,
+  `coincidence_config.py` (aligning multiple detectors on the same mass —
+  **coincidence** — via `jobs/coincidence.py`).
+
+Peak centering is run routinely before/within an analysis; if the center is
+wrong, every subsequent intensity is wrong.
+
+---
+
+## 7. Scans & tuning jobs
+
+`pychron/spectrometer/jobs/` — diagnostic/calibration sweeps, mostly subclasses
+of `BaseSweep`/`BaseScanner`:
+
+| Job | Sweeps | Purpose |
+|-----|--------|---------|
+| `magnet_scan.py` / `magnet_sweep.py` | magnet DAC | see the spectrum / locate masses |
+| `mass_scanner.py` | mass | spectrum vs amu |
+| `peak_center.py` | magnet or HV | center a peak (§6) |
+| `hv_sweep.py` (`HVSweep`) | acceleration voltage | HV-based centering/tuning |
+| `cdd_operating_voltage_scan.py` | ion-counter HV | set CDD operating plateau |
+| `dac_scanner.py` | arbitrary DAC | generic source/optics tuning |
+| `coincidence.py` | — | align detectors on one mass |
+
+`scan_manager.py` and `readout_view.py` drive live scanning/monitoring;
+`spectrometer_parameters.py` holds the editable parameter set.
+
+---
+
+## 8. Pitfalls for an editing agent
+
+- **DAC vs mass are not interchangeable** — always go through the MFTABLE
+  (`map_mass_to_dac`/`map_dac_to_mass`); each detector has its own mapping.
+- **Field ∝ √(m/z) at fixed HV** — changing HV shifts where masses land; HV and
+  magnet are two ways to center the same peak.
+- Source parameters interact: trap current ↔ sensitivity ↔ beam shape ↔
+  resolution. A change tuned for signal can degrade peak flatness.
+- Don't conflate **gain** (detector amplification, → IC factor) with
+  **sensitivity** (source ionization efficiency, → smallest datable sample).
+- Vendor backends differ in commands and available parameters; edit the base
+  class only when behavior is genuinely shared, otherwise patch the specific
+  `thermo/`, `isotopx/`, or `pfeiffer/` implementation.
+- Static-vacuum operation means signals decay/grow during measurement (memory,
+  pumping, blank growth); time-zero extrapolation is intentional, not a bug.

--- a/docs/ai/noble_gas_mass_spectrometer.md
+++ b/docs/ai/noble_gas_mass_spectrometer.md
@@ -1,8 +1,9 @@
 # Noble-Gas Mass Spectrometer — Domain Primer for Agents
 
-Companion to `docs/ai/arar_geochronology.md`. That doc covers the *science*
-(turning argon isotopes into ages); this one covers the *instrument* that
-measures those isotopes. Read it before editing `pychron/spectrometer`,
+Companion to `docs/ai/arar_geochronology.md` (the *science* — turning argon
+isotopes into ages) and `docs/ai/extraction_and_uhv.md` (the *front end* — the
+UHV line that extracts and delivers the gas). This one covers the *instrument*
+that measures those isotopes. Read it before editing `pychron/spectrometer`,
 `pychron/spectrometer/ion_optics`, `pychron/spectrometer/jobs`, or detector/
 magnet/source device code — it explains *why* parameters like resolution,
 sensitivity, peak center, deflection, and acceleration voltage exist and how


### PR DESCRIPTION
## What

Adds two agent-facing **domain primers** under `docs/ai/`, explaining the *science and instrument* behind the code so agents understand the *purpose* of functions/methods/workflows — not just structure.

- **`docs/ai/arar_geochronology.md`** — the ⁴⁰Ar/³⁹Ar method
  - Lab workflow (irradiation → extraction → measurement → reduction → interpretation) mapped to subsystems
  - Measurement model: 5 argon isotopes, blank/baseline/IC/discrimination/decay corrections
  - **Time zero**: intensity-vs-time regression extrapolated to gas inlet (`_predict_at_t_zero`, `offset_xs`)
  - Reduction math: interference → atmospheric → cosmogenic → `F = ⁴⁰Ar*/³⁹ArK` → age equation, each mapped to functions in `argon_calculations.py`
  - **Interpretation & statistics**: isochron (York regressors), plateau (Fleck/gas-fraction), ideogram (KDE/cumulative probability), error propagation (`uncertainties`/`ufloat`, MSWD)
  - Glossary → code map, decay-constant reference, editing pitfalls
- **`docs/ai/noble_gas_mass_spectrometer.md`** — the instrument
  - Ion source / acceleration voltage / trap / symmetry / deflection (sensitivity & beam shape)
  - Magnet & MFTABLE mass dispersion (`map_mass_to_dac`)
  - Detectors: Faraday vs CDD, gain, deflection
  - Resolution & resolving power (`calculate_resolution`)
  - Peak centering and tuning scans
- **`AGENTS.md`** — new *Domain Context* section pointing agents to both primers before editing the science/instrument layers.

## Why

Existing agent docs (`AGENTS.md`, `docs/ai/*.yaml`) map code structure but omit the domain. These primers fill the "why" gap so agents make better-grounded changes in `pychron/processing`, `pychron/pipeline`, `pychron/spectrometer`, etc.

## Notes for reviewer

- **Docs only — no code changes**, zero regression risk.
- All content is grounded in real symbols (function names, traits, constants) from the current source; worth a sanity check that the science descriptions match lab convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)