### PR TITLE
Merge dc2025 cryo setpoint limits; fix uv lock win32 resolution

### DIFF
--- a/pychron/hardware/base_cryo_controller.py
+++ b/pychron/hardware/base_cryo_controller.py
@@ -16,14 +16,14 @@
 import string
 import time
 
-from traits.api import Float
+from traits.api import Bool, Float
 
 from pychron.hardware import get_float
 from pychron.hardware.core.core_device import CoreDevice
 
 
 class BaseCryoController(CoreDevice):
-    verify_setpoint = True
+    verify_setpoint = Bool(True)
 
     # configurable setpoint limits. defaults permissive (no limit)
     setpoint_min = Float(float("-inf"))

--- a/pychron/hardware/base_cryo_controller.py
+++ b/pychron/hardware/base_cryo_controller.py
@@ -16,12 +16,70 @@
 import string
 import time
 
+from traits.api import Float
+
 from pychron.hardware import get_float
 from pychron.hardware.core.core_device import CoreDevice
 
 
 class BaseCryoController(CoreDevice):
     verify_setpoint = True
+
+    # configurable setpoint limits. defaults permissive (no limit)
+    setpoint_min = Float(float("-inf"))
+    setpoint_max = Float(float("inf"))
+
+    def load_additional_args(self, config):
+        self._load_setpoint_limits(config)
+        return super().load_additional_args(config)
+
+    def _load_setpoint_limits(self, config):
+        # [Setpoint]
+        # min=0
+        # max=325
+        self.set_attribute(
+            config,
+            "setpoint_min",
+            "Setpoint",
+            "min",
+            cast="float",
+            optional=True,
+            default=float("-inf"),
+        )
+        self.set_attribute(
+            config,
+            "setpoint_max",
+            "Setpoint",
+            "max",
+            cast="float",
+            optional=True,
+            default=float("inf"),
+        )
+
+    def _setpoint_limits(self, output=1):
+        """Return (min, max) for the given output. Override for per-channel."""
+        return self.setpoint_min, self.setpoint_max
+
+    def _validate_setpoint(self, v, output=1):
+        """Return float v if within the output's [min, max], else None.
+
+        Warns user on out-of-range. Used to gate programmatic set_setpoint.
+        """
+        try:
+            v = float(v)
+        except (TypeError, ValueError):
+            self.warning("invalid setpoint value: {}".format(v))
+            return
+
+        lo, hi = self._setpoint_limits(output)
+        if v < lo or v > hi:
+            self.warning_dialog(
+                "Setpoint {} (output {}) out of range. "
+                "Must be between {} and {}".format(v, output, lo, hi)
+            )
+            return
+
+        return v
 
     def setpoints_achieved(self, setpoints, tol=1):
         pass
@@ -49,6 +107,10 @@ class BaseCryoController(CoreDevice):
         return self._read_input(v, **kw)
 
     def set_setpoint(self, v, output=1, retries=3):
+        v = self._validate_setpoint(v, output)
+        if v is None:
+            return
+
         sp = None
         for i in range(retries):
             self._write_setpoint(v, output)

--- a/pychron/hardware/lakeshore/base_controller.py
+++ b/pychron/hardware/lakeshore/base_controller.py
@@ -133,7 +133,7 @@ class BaseLakeShoreController(BaseCryoController):
 
     graph_klass = StreamStackedGraph
 
-    verify_setpoint = Bool
+    verify_setpoint = Bool(False)
 
     protocol_kind = Enum("GPIB", "SCPI")
     protocol = None

--- a/pychron/hardware/lakeshore/base_controller.py
+++ b/pychron/hardware/lakeshore/base_controller.py
@@ -196,9 +196,7 @@ class BaseLakeShoreController(BaseCryoController):
             cast="boolean",
         )
 
-        self.set_attribute(
-            config, "protocol_kind", "Communications", "protocol", default="GPIB"
-        )
+        self.set_attribute(config, "protocol_kind", "Communications", "protocol", default="GPIB")
         self.set_attribute(
             config,
             "verify_setpoint",

--- a/pychron/hardware/lakeshore/base_controller.py
+++ b/pychron/hardware/lakeshore/base_controller.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 
 from traits.api import Enum, Float, Property, List, Int, Bool
-from traitsui.api import Item, UItem, HGroup, VGroup, Spring
+from traitsui.api import Item, UItem, HGroup, VGroup, Spring, RangeEditor
 
 from pychron.core.pychron_traits import BorderVGroup
 from pychron.core.ui.lcd_editor import LCDEditor
@@ -118,6 +118,13 @@ class BaseLakeShoreController(BaseCryoController):
     setpoint1_readback = Float
     setpoint2 = Float(auto_set=False, enter_set=True)
     setpoint2_readback = Float
+
+    # per-channel setpoint limits. default permissive, overwritten in load
+    num_outputs = 2
+    setpoint1_min = Float(float("-inf"))
+    setpoint1_max = Float(float("inf"))
+    setpoint2_min = Float(float("-inf"))
+    setpoint2_max = Float(float("inf"))
     range_tests = List
     num_inputs = Int
     ionames = List
@@ -131,7 +138,46 @@ class BaseLakeShoreController(BaseCryoController):
     protocol_kind = Enum("GPIB", "SCPI")
     protocol = None
 
+    def _load_setpoint_limits(self, config):
+        # [Setpoint]
+        # min=0          ; global default for all outputs
+        # max=325
+        # 1_min=0        ; per-output overrides (optional)
+        # 1_max=100
+        # 2_min=50
+        # 2_max=325
+        super()._load_setpoint_limits(config)
+        for i in range(1, self.num_outputs + 1):
+            self.set_attribute(
+                config,
+                "setpoint{}_min".format(i),
+                "Setpoint",
+                "{}_min".format(i),
+                cast="float",
+                optional=True,
+                default=self.setpoint_min,
+            )
+            self.set_attribute(
+                config,
+                "setpoint{}_max".format(i),
+                "Setpoint",
+                "{}_max".format(i),
+                cast="float",
+                optional=True,
+                default=self.setpoint_max,
+            )
+
+    def _setpoint_limits(self, output=1):
+        try:
+            output = int(re.sub("[^0-9]", "", str(output)))
+        except (TypeError, ValueError):
+            output = 1
+        lo = getattr(self, "setpoint{}_min".format(output), self.setpoint_min)
+        hi = getattr(self, "setpoint{}_max".format(output), self.setpoint_max)
+        return lo, hi
+
     def load_additional_args(self, config):
+        self._load_setpoint_limits(config)
         self.set_attribute(config, "units", "General", "units", default="K")
         self.set_attribute(
             config,
@@ -259,6 +305,10 @@ class BaseLakeShoreController(BaseCryoController):
         self.protocol.set_setpoint(output, v, **kw)
 
     def set_setpoint(self, v, output=1, retries=3):
+        v = self._validate_setpoint(v, output)
+        if v is None:
+            return
+
         self.set_range(v, output)
         super().set_setpoint(v, output, retries)
         # for i in range(retries):
@@ -326,7 +376,14 @@ class BaseLakeShoreController(BaseCryoController):
                     style="readonly",
                     editor=LCDEditor(width=120, ndigits=6, height=30),
                 ),
-                Item("setpoint1"),
+                Item(
+                    "setpoint1",
+                    editor=RangeEditor(
+                        low_name="setpoint1_min",
+                        high_name="setpoint1_max",
+                        mode="text",
+                    ),
+                ),
                 UItem(
                     "setpoint1_readback",
                     editor=LCDEditor(width=120, height=30),
@@ -341,7 +398,14 @@ class BaseLakeShoreController(BaseCryoController):
                     style="readonly",
                     editor=LCDEditor(width=120, ndigits=6, height=30),
                 ),
-                Item("setpoint2"),
+                Item(
+                    "setpoint2",
+                    editor=RangeEditor(
+                        low_name="setpoint2_min",
+                        high_name="setpoint2_max",
+                        mode="text",
+                    ),
+                ),
                 UItem(
                     "setpoint2_readback",
                     editor=LCDEditor(width=120, height=30),

--- a/pychron/hardware/lakeshore/model330.py
+++ b/pychron/hardware/lakeshore/model330.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ===============================================================================
 
-from traitsui.api import Item, UItem, HGroup, VGroup, Spring
+from traitsui.api import Item, UItem, HGroup, VGroup, Spring, RangeEditor
 
 from pychron.core.ui.lcd_editor import LCDEditor
 from pychron.hardware.lakeshore.base_controller import BaseLakeShoreController
@@ -68,7 +68,14 @@ class Model330TemperatureController(BaseLakeShoreController):
                     style="readonly",
                     editor=LCDEditor(width=120, ndigits=6, height=30),
                 ),
-                Item("setpoint1"),
+                Item(
+                    "setpoint1",
+                    editor=RangeEditor(
+                        low_name="setpoint1_min",
+                        high_name="setpoint1_max",
+                        mode="text",
+                    ),
+                ),
                 UItem(
                     "setpoint1_readback",
                     editor=LCDEditor(width=120, height=30),

--- a/pychron/hardware/lakeshore/model336.py
+++ b/pychron/hardware/lakeshore/model336.py
@@ -14,7 +14,17 @@
 # limitations under the License.
 # ===============================================================================
 from __future__ import absolute_import
-from traitsui.api import Group, Item, UItem, HGroup, VGroup, spring, Spring, Label
+from traitsui.api import (
+    Group,
+    Item,
+    UItem,
+    HGroup,
+    VGroup,
+    spring,
+    Spring,
+    Label,
+    RangeEditor,
+)
 from traits.api import Float, Int
 
 from pychron.core.ui.lcd_editor import LCDEditor
@@ -22,12 +32,18 @@ from pychron.hardware.lakeshore.base_controller import BaseLakeShoreController
 
 
 class Model336TemperatureController(BaseLakeShoreController):
+    num_outputs = 4
     input_c = Float
     input_d = Float
     setpoint3 = Float(auto_set=False, enter_set=True)
     setpoint3_readback = Float
     setpoint4 = Float(auto_set=False, enter_set=True)
     setpoint4_readback = Float
+
+    setpoint3_min = Float(float("-inf"))
+    setpoint3_max = Float(float("inf"))
+    setpoint4_min = Float(float("-inf"))
+    setpoint4_max = Float(float("inf"))
 
     def read_input_c(self, **kw):
         return self._read_input("c", self.units, **kw)
@@ -49,7 +65,14 @@ class Model336TemperatureController(BaseLakeShoreController):
             contents = []
             if self.iomap[i] is not None:
                 contents = [
-                    Item("{}".format(self.iomap[i])),
+                    Item(
+                        "{}".format(self.iomap[i]),
+                        editor=RangeEditor(
+                            low_name="{}_min".format(self.iomap[i]),
+                            high_name="{}_max".format(self.iomap[i]),
+                            mode="text",
+                        ),
+                    ),
                     UItem(
                         "{}_readback".format(self.iomap[i]),
                         editor=LCDEditor(width=120, height=30),

--- a/pychron/hardware/lakeshore/model336.py
+++ b/pychron/hardware/lakeshore/model336.py
@@ -89,7 +89,7 @@ class Model336TemperatureController(BaseLakeShoreController):
                         style="readonly",
                         editor=LCDEditor(width=120, ndigits=6, height=30),
                     ),
-                    *contents
+                    *contents,
                 ),
             )
             items.append(h)

--- a/pychron/hardware/si9700.py
+++ b/pychron/hardware/si9700.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 import string
 from traits.api import Float
-from traitsui.api import VGroup, Item, UItem
+from traitsui.api import VGroup, Item, UItem, RangeEditor
 
 from pychron.core.ui.lcd_editor import LCDEditor
 from pychron.hardware import get_float
@@ -39,7 +39,10 @@ class SI9700Controller(BaseCryoController):
         return True
 
     def set_setpoints(self, *setpoints, block=False, delay=1):
-        self.ask(f"SET {setpoints[0]}")
+        v = self._validate_setpoint(setpoints[0])
+        if v is None:
+            return
+        self.ask(f"SET {v}")
 
     def _write_setpoint(self, v, *args, **kw):
         self.ask(f"SET {v}")
@@ -63,7 +66,14 @@ class SI9700Controller(BaseCryoController):
 
     def get_control_group(self):
         grp = VGroup(
-            Item("setpoint"),
+            Item(
+                "setpoint",
+                editor=RangeEditor(
+                    low_name="setpoint_min",
+                    high_name="setpoint_max",
+                    mode="text",
+                ),
+            ),
             UItem(
                 "readback",
                 editor=LCDEditor(width=120, height=30),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ required-environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
     "sys_platform == 'darwin' and platform_machine == 'x86_64'"
 ]
+# pyqt5-qt5 >5.15.2 dropped win_amd64 wheels; pin the last version that
+# ships one on Windows so `uv lock` stays resolvable across all required envs.
+constraint-dependencies = [
+    "pyqt5-qt5==5.15.2; sys_platform == 'win32' and platform_machine == 'AMD64'",
+]
 
 [project]
 name = "pychrondc"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "platform_machine != 'AMD64' or sys_platform != 'win32'",
@@ -460,6 +460,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -556,7 +565,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1223,8 +1231,7 @@ dependencies = [
     { name = "pygments" },
     { name = "pymysql" },
     { name = "pyproj" },
-    { name = "pyqt5", version = "5.15.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "pyqt5", version = "5.15.11", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+    { name = "pyqt5" },
     { name = "pyyaml" },
     { name = "qimage2ndarray" },
     { name = "reportlab" },
@@ -1301,9 +1308,10 @@ requires-dist = [
     { name = "pg8000", specifier = ">=1.31.2,<2" },
     { name = "prometheus-client", specifier = ">=0.25.0,<1" },
     { name = "pygments", specifier = ">=2.19.2,<3" },
+    { name = "pymodbus", marker = "extra == 'hardware'", specifier = ">=3.12,<4" },
     { name = "pymysql", specifier = ">=1.1.2,<2" },
     { name = "pyproj", specifier = ">=3.7.2,<4" },
-    { name = "pyqt5", specifier = ">=5.15.2,<6" },
+    { name = "pyqt5", specifier = ">=5.15.11,<6" },
     { name = "pyserial", marker = "extra == 'hardware'", specifier = ">=3.5,<4" },
     { name = "pyserial", marker = "extra == 'laser'", specifier = ">=3.5,<4" },
     { name = "pyserial", marker = "extra == 'ngx'", specifier = ">=3.5,<4" },
@@ -1428,26 +1436,12 @@ wheels = [
 
 [[package]]
 name = "pyqt5"
-version = "5.15.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "platform_machine == 'AMD64' and sys_platform == 'win32'",
-]
-dependencies = [
-    { name = "pyqt5-sip", marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/6c/640e3f5c734c296a7193079a86842a789edb7988dca39eab44579088a1d1/PyQt5-5.15.2.tar.gz", hash = "sha256:372b08dc9321d1201e4690182697c5e7ffb2e0770e6b4a45519025134b12e4fc", size = 3265445, upload-time = "2020-11-24T10:34:39.87Z" }
-
-[[package]]
-name = "pyqt5"
 version = "5.15.11"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "platform_machine != 'AMD64' or sys_platform != 'win32'",
-]
 dependencies = [
-    { name = "pyqt5-qt5", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
-    { name = "pyqt5-sip", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+    { name = "pyqt5-qt5", version = "5.15.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+    { name = "pyqt5-qt5", version = "5.15.18", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+    { name = "pyqt5-sip" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/07/c9ed0bd428df6f87183fca565a79fee19fa7c88c7f00a7f011ab4379e77a/PyQt5-5.15.11.tar.gz", hash = "sha256:fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52", size = 3216775, upload-time = "2024-07-19T08:39:57.756Z" }
 wheels = [
@@ -1460,8 +1454,22 @@ wheels = [
 
 [[package]]
 name = "pyqt5-qt5"
+version = "5.15.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'AMD64' and sys_platform == 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/97/5d3b222b924fa2ed4c2488925155cd0b03fd5d09ee1cfcf7c553c11c9f66/PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962", size = 50075158, upload-time = "2021-03-10T14:05:20.868Z" },
+]
+
+[[package]]
+name = "pyqt5-qt5"
 version = "5.15.18"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 'AMD64' or sys_platform != 'win32'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/90/bf01ac2132400997a3474051dd680a583381ebf98b2f5d64d4e54138dc42/pyqt5_qt5-5.15.18-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:8bb997eb903afa9da3221a0c9e6eaa00413bbeb4394d5706118ad05375684767", size = 39715743, upload-time = "2025-11-09T12:56:42.936Z" },
     { url = "https://files.pythonhosted.org/packages/24/8e/76366484d9f9dbe28e3bdfc688183433a7b82e314216e9b14c89e5fab690/pyqt5_qt5-5.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c656af9c1e6aaa7f59bf3d8995f2fa09adbf6762b470ed284c31dca80d686a26", size = 36798484, upload-time = "2025-11-09T12:56:59.998Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,9 @@ required-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 
+[manifest]
+constraints = [{ name = "pyqt5-qt5", marker = "platform_machine == 'AMD64' and sys_platform == 'win32'", specifier = "==5.15.2" }]
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -1240,6 +1243,7 @@ dependencies = [
     { name = "scikit-image" },
     { name = "scipy" },
     { name = "segno" },
+    { name = "setuptools" },
     { name = "six" },
     { name = "sqlalchemy" },
     { name = "statsmodels" },
@@ -1325,6 +1329,7 @@ requires-dist = [
     { name = "scikit-image", specifier = ">=0.26.0,<1" },
     { name = "scipy", specifier = ">=1.16.2,<2" },
     { name = "segno", specifier = ">=1.6,<2" },
+    { name = "setuptools", specifier = "<81" },
     { name = "six", specifier = ">=1.17.0,<2" },
     { name = "sqlalchemy", specifier = ">=2.0.44,<3" },
     { name = "statsmodels", specifier = ">=0.14.5,<1" },


### PR DESCRIPTION
## Summary

- Merges `AELAMSPychron/dev/dc2025` into this branch, bringing two upstream commits:
  - feat: configurable setpoint min/max limits for cryo devices (lakeshore model330/336, si9700, base cryo controller)
  - fix: repaired `uv.lock` and applied black formatting
- Fixes `uv lock` regeneration, which was failing to resolve the required `win32/AMD64` environment.

## Context

- After the merge, `uv lock` could not regenerate: `pyqt5-qt5` versions newer than 5.15.2 dropped `win_amd64` wheels, so uv picked the latest (5.15.18) for all platforms and the Windows environment became unsatisfiable.
- dc2025 had worked around this with a manual per-platform split in the lock that plain `uv lock` cannot reproduce.
- Added a marker-scoped constraint pinning `pyqt5-qt5==5.15.2` on Windows so the lock stays resolvable across all required environments; other platforms keep the latest (5.15.18).

## Verification

- [ ] Tests added or updated where appropriate
- [x] Local verification completed
- [x] CI is expected to pass

Verification details:

- `uv lock` resolves 142 packages successfully
- `uv lock --check` passes (lockfile consistent)
- Windows pin held: `pyqt5-qt5==5.15.2` for `win32/AMD64`, `5.15.18` elsewhere

## Risk

- Low. The only dependency change is a Windows-only pin of `pyqt5-qt5` to 5.15.2 (the last version shipping a `win_amd64` wheel). Non-Windows platforms unchanged.
- Cryo setpoint limit changes are additive (configurable min/max).

## Target Branch Check

- [ ] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`)

## Follow-ups

- None.
