### PR TITLE
fix(hardware): repair validation report serialization, config template section handling, and filter reset test

### DIFF
--- a/pychron/hardware/config_template.py
+++ b/pychron/hardware/config_template.py
@@ -51,8 +51,7 @@ class ConfigTemplate:
         config = configparser.ConfigParser()
 
         # Add device name and class info
-        if "General" not in self.settings:
-            config.add_section("General")
+        config.add_section("General")
         config.set("General", "name", device_name)
         config.set("General", "device_class", self.device_class)
 

--- a/pychron/hardware/tests/test_phase2.py
+++ b/pychron/hardware/tests/test_phase2.py
@@ -244,9 +244,9 @@ class TestLibraryFilter(unittest.TestCase):
         filter_obj.reset()
 
         self.assertEqual(filter_obj.search_text, "")
-        self.assertIsNone(filter_obj.company_filter)
-        self.assertIsNone(filter_obj.comm_type_filter)
-        self.assertIsNone(filter_obj.completeness_filter)
+        self.assertEqual(filter_obj.company_filter, "")
+        self.assertEqual(filter_obj.comm_type_filter, "")
+        self.assertEqual(filter_obj.completeness_filter, "")
 
 
 class TestLibrarySearcher(unittest.TestCase):

--- a/pychron/hardware/validation_reporter.py
+++ b/pychron/hardware/validation_reporter.py
@@ -66,8 +66,8 @@ class ValidationReport:
     @property
     def incomplete_entries_sorted(self) -> List[tuple]:
         """Get incomplete entries sorted by number of missing fields."""
-        items = [(name, len(fields)) for name, fields in self.missing_fields_by_entry.items()]
-        return sorted(items, key=lambda x: x[1], reverse=True)
+        items = [(name, fields or []) for name, fields in self.missing_fields_by_entry.items()]
+        return sorted(items, key=lambda x: len(x[1]), reverse=True)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert report to dictionary."""


### PR DESCRIPTION
## Summary

- Fixed `ValidationReport.incomplete_entries_sorted` to return `(name, fields_list)` tuples instead of `(name, count)`, resolving `TypeError: can only join an iterable` in `to_html()` and `to_csv()`. None field lists are guarded with `or []`; sorting by field count (descending) is preserved.
- Fixed `ConfigTemplate.to_config_content` raising `configparser.NoSectionError` whenever template settings contained a `General` section: the guard checked `self.settings` instead of the freshly created `ConfigParser`, so `add_section("General")` was skipped exactly when it was needed. The section is now added unconditionally.
- Aligned `test_filter_reset` with the actual `LibraryFilter` contract: Traits `Str` cannot hold `None` (assignment raises `TraitError`) and `matches()` treats `""` as no-filter, so `reset()` correctly restores `""`. The test now asserts `""` for all four filters, consistent with its own `search_text` assertion.

## Context

- Three pre-existing failures (plus one related error in phase 3 tests) in the hardware library suite blocked a green run of `uv run python -m unittest discover -s pychron/hardware -p '*test*.py'`.
- The `to_html`/`to_csv` and `ConfigTemplate` issues were real production bugs that would also fail at runtime, not just in tests; the filter reset failure was a test asserting an impossible contract.

## Verification

- [x] Tests added or updated where appropriate
- [x] Local verification completed
- [x] CI is expected to pass

Verification details:

- `uv run python -m unittest discover -s pychron/hardware -p '*test*.py'` — 275 tests, OK (previously 1 failure + 3 errors)

## Risk

- Low risk. `incomplete_entries_sorted` is only consumed by `to_html`/`to_csv` within the same module, and both were broken before this change. `ConfigTemplate` change only affects the previously failing code path. No behavioral change to `LibraryFilter` itself.

## Target Branch Check

- [x] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`) — targets `main`, the repo default and base of this worktree branch

## Follow-ups

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)