### PR TITLE
ci: align Black version with pre-commit and fix push-event changed-file detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Determine Python files to check
         id: changed-python
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: |
           python <<'PY' >> "$GITHUB_OUTPUT"
           import os
@@ -75,8 +77,9 @@ jobs:
                   base = os.environ["GITHUB_BASE_REF"]
                   cmd = ["git", "diff", "--name-only", "--diff-filter=d", f"origin/{base}...HEAD", "--", "*.py"]
               else:
-                  before = os.environ.get("GITHUB_EVENT_BEFORE")
-                  if before:
+                  before = os.environ.get("GITHUB_EVENT_BEFORE", "")
+                  # All-zero SHA means no usable base (new branch or force push)
+                  if before and set(before) != {"0"}:
                       cmd = ["git", "diff", "--name-only", "--diff-filter=d", before, "HEAD", "--", "*.py"]
                   else:
                       cmd = ["git", "ls-files", "*.py"]
@@ -124,6 +127,8 @@ jobs:
 
       - name: Determine Python files to check
         id: changed-python
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: |
           python <<'PY' >> "$GITHUB_OUTPUT"
           import os
@@ -143,8 +148,9 @@ jobs:
                   base = os.environ["GITHUB_BASE_REF"]
                   cmd = ["git", "diff", "--name-only", "--diff-filter=d", f"origin/{base}...HEAD", "--", "*.py"]
               else:
-                  before = os.environ.get("GITHUB_EVENT_BEFORE")
-                  if before:
+                  before = os.environ.get("GITHUB_EVENT_BEFORE", "")
+                  # All-zero SHA means no usable base (new branch or force push)
+                  if before and set(before) != {"0"}:
                       cmd = ["git", "diff", "--name-only", "--diff-filter=d", before, "HEAD", "--", "*.py"]
                   else:
                       cmd = ["git", "ls-files", "*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,8 @@ valve = [
 
 [dependency-groups]
 dev = [
-    "black",
+    # Pin to the same version as .pre-commit-config.yaml so CI and pre-commit agree
+    "black==24.10.0",
     "mypy>=1.20.1,<2",
     "pre-commit>=4.2.0,<5",
     "types-requests",

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "26.3.1"
+version = "24.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -143,16 +143,14 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
-    { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813, upload-time = "2024-10-07T19:20:50.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
-    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256, upload-time = "2024-10-07T19:27:53.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534, upload-time = "2024-10-07T19:26:44.953Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892, upload-time = "2024-10-07T19:24:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796, upload-time = "2024-10-07T19:25:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898, upload-time = "2024-10-07T19:20:48.317Z" },
 ]
 
 [[package]]
@@ -1348,7 +1346,7 @@ provides-extras = ["hardware", "laser", "spectrometer-ngx", "ngx", "valve"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black" },
+    { name = "black", specifier = "==24.10.0" },
     { name = "mypy", specifier = ">=1.20.1,<2" },
     { name = "pre-commit", specifier = ">=4.2.0,<5" },
     { name = "traits-stubs", specifier = ">=6.4.0" },
@@ -1526,20 +1524,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/88/815e53084c5079a59df912825a279f41dd2e0df82281770eadc732f5352c/python_discovery-1.2.1.tar.gz", hash = "sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e", size = 58457, upload-time = "2026-03-26T22:30:44.496Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl", hash = "sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502", size = 31674, upload-time = "2026-03-26T22:30:43.396Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pinned the dev-group `black` dependency to `24.10.0`, matching the `.pre-commit-config.yaml` rev, and regenerated `uv.lock` (only change: black 26.3.1 → 24.10.0, transitive `pytokens` removed). CI previously checked formatting with Black 26.x stable style while pre-commit formatted commits with 24.10.0.
- Fixed changed-file detection in the Black and MyPy jobs for `push` events: the script read `GITHUB_EVENT_BEFORE`, but GitHub never exports that as an environment variable — it only exists as the `github.event.before` context. The variable is now exported via step `env`, and an all-zero SHA (new branch / force push) is treated as unusable, falling back to the existing full-tree behavior.

## Context

- Black and MyPy jobs fail on every push to `main` even when the pushed files are clean (e.g. the run for #35, whose three files pass `black --check`).
- Because `GITHUB_EVENT_BEFORE` was always empty on push, the jobs fell back to `git ls-files` and checked all ~2300 files, hitting ~750 legacy files that were never Black-formatted. Pull request runs diff against the base branch and were unaffected.
- The version mismatch additionally meant a file formatted by the pre-commit hook could still fail CI's newer stable style (916 files fail under 26.3.1 vs 754 under 24.10.0).

## Verification

- [x] Tests added or updated where appropriate (n/a — CI config and dependency pin only)
- [x] Local verification completed
- [x] CI is expected to pass

Verification details:

- `uv lock` then `uv sync --group dev`: only black downgraded; `black --version` reports 24.10.0
- Workflow YAML parses (`yaml.safe_load`)
- Simulated the detection script: valid `before` SHA → diff mode returns only pushed files; all-zero SHA → correctly treated as unusable
- This PR itself exercises the pull-request path of both jobs

## Risk

- Low. Lint/typecheck tooling only; no runtime code changes. Push-event behavior change: jobs now check only pushed files instead of the whole tree, which matches the pull-request behavior and the original intent of the detection script. MyPy will still report pre-existing type errors in any legacy files that are touched.

## Target Branch Check

- [x] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`) — targets `main`, the repo default, which this branch was cut from

## Follow-ups

- Repo-wide `black .` under 24.10.0 (~754 files) if a fully formatted tree is wanted; until then, full-tree fallback paths (new branch pushes) will still fail.
- MyPy has ~2100 pre-existing errors repo-wide; needs a baseline or targeted cleanup as a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)