### PR TITLE
docs: require f-strings for string formatting in touched code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,10 @@ Code Changes
 ============
 
 - Prefer focused edits over opportunistic refactors.
+- Always use f-string syntax for string formatting in new and edited code. When
+  you touch a line or function that uses `str.format(...)` or `%` formatting,
+  replace it with an f-string as part of the edit. Do not sweep the repo
+  converting `.format` calls outside the code you are already changing.
 - Add type annotations to any function you touch. If a full signature annotation
   would force broader churn, annotate the parameters and return value needed for
   the current edit and keep the rest of the change scoped.


### PR DESCRIPTION
## Summary

- Adds a rule to `AGENTS.md` (Code Changes): always use f-strings in new and edited code, and convert `str.format(...)` / `%` formatting to f-strings when touching a line or function that uses them.
- Scoped to touched code only — explicitly forbids repo-wide `.format` sweeps, consistent with the existing "do not mass-format unrelated files" policy.

## Context

- The codebase carries a large amount of legacy `.format()` usage; this codifies incremental migration to f-strings without inviting bulk rewrites.

## Verification

- [x] Tests added or updated where appropriate (n/a — docs only)
- [x] Local verification completed (n/a — docs only)
- [x] CI is expected to pass

Verification details:

- Docs-only change; no Python files touched.

## Risk

- None. Documentation only.

## Target Branch Check

- [x] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`) — targets `main`, the repo default, which this branch was cut from

## Follow-ups

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)