### PR TITLE
refactor(hardware): deprecate custom message framing in ethernet communicator

### DIFF
--- a/pychron/hardware/core/communicators/ethernet_communicator.py
+++ b/pychron/hardware/core/communicators/ethernet_communicator.py
@@ -35,6 +35,15 @@ from pychron.regex import IPREGEX
 
 
 class MessageFrame(object):
+    """Length-prefix/CRC framing for ethernet messages.
+
+    .. deprecated::
+        The custom framing protocol (hex length prefix + CRC16, configured via
+        a ``message_frame`` string such as ``L4,-,C4``) was experimental and is
+        slated for removal. Use terminator-based reads instead, or a standard
+        transport (e.g. ZeroMQ) for pychron-to-pychron links.
+    """
+
     def __init__(self, message_len=False, nmessage_len=4, checksum=False, nchecksum=4):
         self.nchecksum = nchecksum
         self.checksum = checksum
@@ -251,6 +260,7 @@ class EthernetCommunicator(Communicator):
     strip = True
     # default_timeout = 3
     default_datasize = 2**12
+    _message_frame_deprecation_warned = False
 
     _comms_report_attrs = (
         "host",
@@ -316,6 +326,8 @@ class EthernetCommunicator(Communicator):
         self.message_frame = self.config_get(
             config, "Communications", "message_frame", optional=True, default=""
         )
+        if self.message_frame:
+            self._warn_message_frame_deprecated("config option 'message_frame'")
         # self.default_timeout = self.config_get(
         #     config,
         #     "Communications",
@@ -337,10 +349,22 @@ class EthernetCommunicator(Communicator):
 
         return True
 
+    def _warn_message_frame_deprecated(self, source: str) -> None:
+        if self._message_frame_deprecation_warned:
+            return
+        self._message_frame_deprecation_warned = True
+        self.warning(
+            f"{source}: the custom message framing protocol (length prefix/CRC, "
+            "e.g. 'L4,-,C4') is deprecated and will be removed. Use "
+            "terminator-based reads or a standard transport instead."
+        )
+
     def open(self, *args, **kw):
         for k in ("host", "port", "message_frame", "kind"):
             if k in kw:
                 setattr(self, k, kw[k])
+        if kw.get("message_frame"):
+            self._warn_message_frame_deprecated("open() keyword 'message_frame'")
 
         if self.transport_adapter is not None:
             self.simulation = True
@@ -473,6 +497,9 @@ class EthernetCommunicator(Communicator):
                 #                                                  self.port, timeout))
                 h.keep_alive = not self.use_end
                 h.open_socket(addrs, timeout=timeout or 1, bind=bind)
+                if self.message_frame:
+                    # catches direct attribute assignment (e.g. pychron_device)
+                    self._warn_message_frame_deprecated("message_frame attribute")
                 h.set_frame(self.message_frame)
                 h.datasize = self.default_datasize
                 h.strip = self.strip
@@ -513,10 +540,12 @@ class EthernetCommunicator(Communicator):
         @param quiet: if true do not log the response
         @param info: str to add to response
         @param timeout: timeout in seconds
-        @param message_frame: MessageFrame object
+        @param message_frame: MessageFrame object (deprecated)
         @param delay: delay in seconds to wait before a `cmd` is sent
 
         """
+        if message_frame is not None:
+            self._warn_message_frame_deprecated("ask() keyword 'message_frame'")
 
         operation_started_at = time.time()
         command_preview = self._command_preview(cmd)

--- a/pychron/hardware/core/tests/ethernet_communicator_test.py
+++ b/pychron/hardware/core/tests/ethernet_communicator_test.py
@@ -201,6 +201,41 @@ class EthernetCommunicatorTestCase(unittest.TestCase):
         self.assertIsNone(communicator.handler)
         self.assertIsNone(communicator.read_handler)
 
+    def test_message_frame_use_warns_deprecation_once(self):
+        communicator = EthernetCommunicator(name="spec_comm")
+        communicator.kind = "TCP"
+        communicator.host = "127.0.0.1"
+        communicator.port = 8000
+        communicator.simulation = False
+        communicator.write_terminator = "\r"
+        communicator.log_response = lambda *args, **kw: None
+        communicator._ask = lambda *args, **kw: "OK"
+        warnings = []
+        communicator.warning = lambda msg: warnings.append(msg)
+
+        frame = MessageFrame(message_len=True, nmessage_len=4)
+        communicator.ask("GetData", verbose=False, message_frame=frame, retries=1)
+        communicator.ask("GetData", verbose=False, message_frame=frame, retries=1)
+
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("deprecated", warnings[0])
+
+    def test_no_deprecation_warning_without_message_frame(self):
+        communicator = EthernetCommunicator(name="spec_comm")
+        communicator.kind = "TCP"
+        communicator.host = "127.0.0.1"
+        communicator.port = 8000
+        communicator.simulation = False
+        communicator.write_terminator = "\r"
+        communicator.log_response = lambda *args, **kw: None
+        communicator._ask = lambda *args, **kw: "OK"
+        warnings = []
+        communicator.warning = lambda msg: warnings.append(msg)
+
+        communicator.ask("GetData", verbose=False, retries=1)
+
+        self.assertEqual(warnings, [])
+
     def test_ask_records_start_and_end_device_io_events(self):
         communicator = EthernetCommunicator(name="spec_comm")
         communicator.kind = "TCP"


### PR DESCRIPTION
## Summary

- Deprecates the experimental length-prefix/CRC `message_frame` protocol (`L4,-,C4`) in `EthernetCommunicator`. It was educational/experimental and is slated for removal.
- Emits a one-time-per-communicator warning when a frame is supplied through any of the four entry points: the `message_frame` config option in `load()`, the `open()` keyword, the `ask()` keyword, or direct attribute assignment (the `pychron_device` path, caught at handler creation).
- `MessageFrame` carries a `.. deprecated::` docstring pointing to terminator-based reads or a standard transport (e.g. ZeroMQ) for pychron-to-pychron links.
- **No behavior change** — framing still works during the deprecation window, so existing configurations are unaffected beyond the log warning.

## Context

- Follow-up to the ethernet comms discussion: the custom framing was confirmed experimental/education-only and can be retired. Live wiring exists in `pychron_device`, `pyscript_runner`, and the laser/extraction-line plugins, but framing only activates when a non-empty frame string is configured; the only `MessageFrame` construction call sites in the tree are commented out.
- Stacked on #37 (base: `fix/ethernet-comms`) since it builds on the repaired `_recvall`. GitHub will retarget to `main` when #37 merges.

## Verification

- [x] Tests added or updated where appropriate
- [x] Local verification completed
- [x] CI is expected to pass

Verification details:

- New tests: warning fires exactly once across repeated framed `ask()` calls; no warning on unframed `ask()`
- `pychron/hardware/core` suite: 118 tests OK; Black and MyPy clean on changed files

## Risk

- Minimal. Warning-only change; framing behavior untouched. Sites with framing configured will see one new warning line per communicator instance.

## Target Branch Check

- [x] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`) — stacked on `fix/ethernet-comms` (#37), retargets to `main` on merge

## Follow-ups

- Removal PR after a deprecation window: delete `MessageFrame`, the frame/checksum branches in `_recvall`, the `message_frame` config plumbing in `pychron_device`/`pyscript_runner`/plugin XML readers, and the framed-read tests
- Migrate pychron-to-pychron links (laser manager, furnace firmware client, pyscript runner) to `ZmqCommunicator` per the transport assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)