### PR TITLE
feat(hardware): harden NGX spectrometer comms

### DIFF
--- a/pychron/hardware/core/communicators/ethernet_communicator.py
+++ b/pychron/hardware/core/communicators/ethernet_communicator.py
@@ -74,6 +74,11 @@ class Handler(object):
     keep_alive = False
     strip = True
 
+    def __init__(self):
+        # partial data carried across a socket.timeout so a line split by a
+        # timeout is not discarded (single stream per handler)
+        self._partial = b""
+
     def set_frame(self, f):
         self.message_frame = MessageFrame()
         if f:
@@ -120,9 +125,20 @@ class Handler(object):
         nm = frame.nmessage_len if frame.message_len else 0
         msg_len = None
 
-        data = b""
+        # resume from any partial line stashed by a previous timeout
+        data = self._partial
+        self._partial = b""
+
         while 1:
-            s = recv(datasize)
+            if terminator is not None and data and data.endswith(terminator):
+                break
+
+            try:
+                s = recv(datasize)
+            except socket.timeout:
+                # keep what we have; the next call resumes from it
+                self._partial = data
+                raise
             if not s:
                 break
 
@@ -261,6 +277,10 @@ class EthernetCommunicator(Communicator):
     # default_timeout = 3
     default_datasize = 2**12
     _message_frame_deprecation_warned = False
+    # called after a new (non-bound) handler connects; use for session setup
+    # such as re-sending a Login after an automatic reconnect
+    on_connect = None
+    _in_on_connect = False
 
     _comms_report_attrs = (
         "host",
@@ -477,6 +497,21 @@ class EthernetCommunicator(Communicator):
 
         return handler
 
+    def _fire_on_connect(self, handler):
+        cb = self.on_connect
+        if cb is None or self._in_on_connect:
+            return
+        # the callback receives the fresh handler and should write session
+        # setup (e.g. Login) directly to it rather than via ask(); the guard
+        # stops a connect->callback->connect loop
+        self._in_on_connect = True
+        try:
+            cb(handler)
+        except BaseException:
+            self.debug_exception()
+        finally:
+            self._in_on_connect = False
+
     def get_handler(self, addrs=None, timeout=None, bind=False):
         if timeout is None:
             timeout = self.timeout
@@ -507,6 +542,7 @@ class EthernetCommunicator(Communicator):
                 # caching them here would clobber and leak the write handler
                 if not bind:
                     self.handler = h
+                    self._fire_on_connect(h)
             return h
         except socket.error as e:
             self.debug(

--- a/pychron/hardware/core/communicators/line_demultiplexer.py
+++ b/pychron/hardware/core/communicators/line_demultiplexer.py
@@ -1,0 +1,182 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Reader-thread demultiplexer for line-oriented instrument streams.
+
+Some instruments (e.g. the Isotopx NGX) interleave asynchronous event pushes
+with command responses on a single TCP stream. Reading that stream from
+multiple call sites races: an ``ask`` issued during an acquisition can consume
+an event line as its response, and concurrent reads interleave bytes.
+
+``LineDemultiplexer`` gives the stream a single owner. A daemon thread reads
+complete lines (terminator-delimited) and routes them: lines starting with
+``event_prefix`` go to an event queue, everything else is treated as a command
+response. ``ask`` pairs each write with the next response line; consumers of
+asynchronous events poll ``get_event``.
+"""
+
+import socket
+import time
+from queue import Empty, Queue
+from threading import Event, Lock, Thread
+from typing import Any, Callable, Optional
+
+
+class LineDemultiplexer:
+    def __init__(
+        self,
+        handler: Any,
+        terminator: str = "#\r\n",
+        event_prefix: str = "#EVENT",
+        warning: Optional[Callable[[str], None]] = None,
+        on_reconnect: Optional[Callable[[], Any]] = None,
+    ):
+        """
+        @param handler: ethernet Handler owning the socket (TCPHandler/UDPHandler)
+        @param terminator: line terminator delimiting both responses and events
+        @param event_prefix: lines starting with this are routed to the event queue
+        @param warning: callable used to surface warnings (e.g. Loggable.warning)
+        @param on_reconnect: called from the reader thread when the connection
+            drops; should return a fresh handler, or None if reconnection failed.
+            The callback may write session setup commands (e.g. Login) directly
+            to the new handler; their responses are drained before the next ask.
+        """
+        self._handler = handler
+        self._terminator = terminator.encode("utf-8") if isinstance(terminator, str) else terminator
+        self._event_prefix = event_prefix
+        self._responses: Queue = Queue()
+        self._events: Queue = Queue()
+        self._write_lock = Lock()
+        self._stop_event = Event()
+        self._thread: Optional[Thread] = None
+        self._warning = warning or (lambda msg: None)
+        self._on_reconnect = on_reconnect
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        if self.running:
+            return
+        self._stop_event.clear()
+        self._thread = Thread(target=self._run, daemon=True, name="line-demux")
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop_event.set()
+        t = self._thread
+        if t is not None and t.is_alive():
+            t.join(timeout)
+        self._thread = None
+
+    def set_handler(self, handler: Any) -> None:
+        self._handler = handler
+
+    def ask(self, payload: str, timeout: float = 3.0) -> Optional[str]:
+        """Send payload, return the next non-event line (or None on timeout)."""
+        with self._write_lock:
+            self._drain(self._responses)
+            handler = self._handler
+            if handler is None:
+                return None
+            try:
+                handler.send_packet(payload)
+            except (socket.error, OSError) as e:
+                self._warning(f"demux send failed: {e}")
+                return None
+            try:
+                return self._responses.get(timeout=timeout)
+            except Empty:
+                return None
+
+    def tell(self, payload: str) -> bool:
+        with self._write_lock:
+            handler = self._handler
+            if handler is None:
+                return False
+            try:
+                handler.send_packet(payload)
+                return True
+            except (socket.error, OSError) as e:
+                self._warning(f"demux send failed: {e}")
+                return False
+
+    def get_event(self, timeout: float = 1.0) -> Optional[str]:
+        try:
+            return self._events.get(timeout=timeout)
+        except Empty:
+            return None
+
+    def clear_events(self) -> None:
+        self._drain(self._events)
+
+    # private
+    def _drain(self, q: Queue) -> None:
+        while True:
+            try:
+                q.get_nowait()
+            except Empty:
+                break
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            handler = self._handler
+            if handler is None or handler.sock is None:
+                if not self._reconnect():
+                    time.sleep(0.25)
+                continue
+
+            try:
+                line = handler.readline(self._terminator)
+            except socket.timeout:
+                continue
+            except (socket.error, OSError) as e:
+                self._warning(f"demux read failed: {e}")
+                self._handler = None
+                continue
+
+            if line is None:
+                continue
+
+            if line == "":
+                # peer closed the connection
+                self._warning("demux: connection closed by peer")
+                self._handler = None
+                continue
+
+            if line.startswith(self._event_prefix):
+                self._events.put(line)
+            else:
+                self._responses.put(line)
+
+    def _reconnect(self) -> bool:
+        cb = self._on_reconnect
+        if cb is None:
+            return False
+        try:
+            handler = cb()
+        except BaseException as e:
+            self._warning(f"demux reconnect failed: {e}")
+            return False
+
+        if handler is None:
+            return False
+
+        self._handler = handler
+        return True
+
+
+# ============= EOF =============================================

--- a/pychron/hardware/core/tests/ethernet_communicator_test.py
+++ b/pychron/hardware/core/tests/ethernet_communicator_test.py
@@ -38,7 +38,10 @@ class _FakeSocket:
 
     def recv(self, datasize):
         if self.recv_chunks:
-            return self.recv_chunks.pop(0)
+            chunk = self.recv_chunks.pop(0)
+            if isinstance(chunk, Exception):
+                raise chunk
+            return chunk
         return b""
 
     def recvfrom(self, datasize):
@@ -120,6 +123,19 @@ class EthernetCommunicatorTestCase(unittest.TestCase):
         response = handler.readline(b"\r\n")
 
         self.assertEqual(response, "AB")
+
+    def test_readline_preserves_partial_line_across_timeout(self):
+        import socket as socket_module
+
+        handler = TCPHandler()
+        handler.sock = _FakeSocket(recv_chunks=[b"PAR", socket_module.timeout(), b"TIAL", b"\r\n"])
+
+        with self.assertRaises(socket_module.timeout):
+            handler.readline(b"\r\n")
+
+        response = handler.readline(b"\r\n")
+
+        self.assertEqual(response, "PARTIAL")
 
     def test_checksum_frame_accepts_valid_crc(self):
         payload = b"TEST"
@@ -276,6 +292,30 @@ class EthernetCommunicatorTestCase(unittest.TestCase):
 
         self.assertEqual(failures[-1][0], "ask")
         self.assertIn("Connection refused", failures[-1][1])
+
+    def test_on_connect_fires_for_new_handler_with_guard(self):
+        communicator = EthernetCommunicator(name="spec_comm")
+        communicator.kind = "TCP"
+        communicator.host = "127.0.0.1"
+        communicator.port = 8000
+        connects = []
+
+        def on_connect(handler):
+            connects.append(handler)
+            # re-entrant get_handler must not fire the hook again
+            communicator.get_handler()
+
+        communicator.on_connect = on_connect
+
+        fake_handler = TCPHandler()
+        fake_handler.sock = _FakeSocket()
+        fake_handler.address = ("127.0.0.1", 8000)
+
+        with mock.patch.object(TCPHandler, "open_socket", lambda self_, addrs, **kw: None):
+            handler = communicator.get_handler()
+
+        self.assertEqual(len(connects), 1)
+        self.assertIs(connects[0], handler)
 
     def test_select_read_with_failed_handler_returns_none(self):
         communicator = EthernetCommunicator(name="spec_comm")

--- a/pychron/hardware/core/tests/line_demultiplexer_test.py
+++ b/pychron/hardware/core/tests/line_demultiplexer_test.py
@@ -1,0 +1,134 @@
+import socket
+import time
+import unittest
+from queue import Empty, Queue
+
+from pychron.hardware.core.communicators.line_demultiplexer import LineDemultiplexer
+
+
+class _ScriptedHandler:
+    """Fake socket handler. Lines pushed via push() are returned by readline;
+    canned responses are released when send_packet is called, emulating a
+    device that replies to commands while also pushing async events."""
+
+    def __init__(self, responses=None):
+        self.sock = object()
+        self.sent = []
+        self.canned = list(responses or [])
+        self._pending = Queue()
+
+    def push(self, line):
+        self._pending.put(line)
+
+    def send_packet(self, payload):
+        self.sent.append(payload)
+        if self.canned:
+            self._pending.put(self.canned.pop(0))
+
+    def readline(self, terminator):
+        try:
+            return self._pending.get(timeout=0.02)
+        except Empty:
+            raise socket.timeout()
+
+
+def _wait_for(predicate, timeout=2.0):
+    st = time.time()
+    while time.time() - st < timeout:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class LineDemultiplexerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.demux = None
+
+    def tearDown(self):
+        if self.demux is not None:
+            self.demux.stop()
+
+    def _start(self, handler, **kw):
+        self.demux = LineDemultiplexer(handler, **kw)
+        self.demux.start()
+        return self.demux
+
+    def test_routes_events_and_responses(self):
+        handler = _ScriptedHandler(responses=["OK#\r\n"])
+        demux = self._start(handler)
+        handler.push("#EVENT:ACQ,NOM,1,2,12:00:00.000,1.0#\r\n")
+
+        response = demux.ask("GetValveStatus\r")
+        event = demux.get_event(timeout=2)
+
+        self.assertEqual(response, "OK#\r\n")
+        self.assertEqual(event, "#EVENT:ACQ,NOM,1,2,12:00:00.000,1.0#\r\n")
+        self.assertEqual(handler.sent, ["GetValveStatus\r"])
+
+    def test_ask_drains_stale_responses(self):
+        handler = _ScriptedHandler(responses=["FRESH#\r\n"])
+        demux = self._start(handler)
+
+        handler.push("STALE#\r\n")
+        self.assertTrue(_wait_for(lambda: not demux._responses.empty()))
+
+        response = demux.ask("Cmd\r")
+
+        self.assertEqual(response, "FRESH#\r\n")
+
+    def test_ask_timeout_returns_none(self):
+        handler = _ScriptedHandler()
+        demux = self._start(handler)
+
+        response = demux.ask("Cmd\r", timeout=0.1)
+
+        self.assertIsNone(response)
+
+    def test_events_do_not_satisfy_ask(self):
+        handler = _ScriptedHandler(responses=["#EVENT:ACQ,NOM,1#\r\n"])
+        demux = self._start(handler)
+
+        response = demux.ask("Cmd\r", timeout=0.2)
+
+        self.assertIsNone(response)
+        self.assertEqual(demux.get_event(timeout=1), "#EVENT:ACQ,NOM,1#\r\n")
+
+    def test_reconnects_after_peer_close(self):
+        first = _ScriptedHandler()
+        second = _ScriptedHandler()
+        reconnects = []
+
+        def on_reconnect():
+            reconnects.append(True)
+            return second
+
+        demux = self._start(first, on_reconnect=on_reconnect)
+        first.push("")  # peer closed
+
+        self.assertTrue(_wait_for(lambda: reconnects))
+        second.push("#EVENT:ACQ,after#\r\n")
+        self.assertEqual(demux.get_event(timeout=2), "#EVENT:ACQ,after#\r\n")
+
+    def test_stop_terminates_reader(self):
+        handler = _ScriptedHandler()
+        demux = self._start(handler)
+        self.assertTrue(demux.running)
+
+        demux.stop()
+
+        self.assertFalse(demux.running)
+
+    def test_clear_events(self):
+        handler = _ScriptedHandler()
+        demux = self._start(handler)
+        handler.push("#EVENT:one#\r\n")
+        self.assertTrue(_wait_for(lambda: not demux._events.empty()))
+
+        demux.clear_events()
+
+        self.assertIsNone(demux.get_event(timeout=0.1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/hardware/isotopx_spectrometer_controller.py
+++ b/pychron/hardware/isotopx_spectrometer_controller.py
@@ -16,28 +16,22 @@
 
 
 # ============= enthought library imports =======================
-from traits.api import Str, HasTraits
+from traits.api import Str, Bool, HasTraits
 from apptools.preferences.preference_binding import bind_preference
 
 # ============= standard library imports ========================
-from threading import RLock, Lock
-from queue import Queue
+from threading import Lock
+import socket
 import time
 
 # ============= local library imports  ==========================
 
 from pychron.hardware.core.core_device import CoreDevice
+from pychron.hardware.core.communicators.line_demultiplexer import LineDemultiplexer
 
-# import ctypes, _thread
-# class mRLock(_thread.RLock):
-#
-#     offsetof_rlock_count = 32 # on 64-bit system
-#
-#     @property
-#     def count(self):
-#         rlock_count_b = ctypes.string_at(id(self)+self.offsetof_rlock_count, 8)
-#         return int.from_bytes(rlock_count_b, 'little', signed=False)
-#
+NGX_TERMINATOR = "#\r\n"
+VALVE_COMMANDS = ("GetValveStatus", "OpenValve", "CloseValve")
+VALVE_RESPONSES = ("E00", "OPEN", "CLOSED")
 
 
 class NGXController(CoreDevice):
@@ -48,31 +42,70 @@ class NGXController(CoreDevice):
     triggered = False
     protect_detector = False
 
+    # route all socket reads through a single reader thread that separates
+    # asynchronous #EVENT pushes from command responses. opt-in until
+    # validated on hardware; enable with use_demux=True in the device config
+    use_demux = Bool(False)
+    max_valve_retries = 3
+    _demux = None
+
+    def load_additional_args(self, config):
+        self.set_attribute(
+            config,
+            "use_demux",
+            "Communications",
+            "use_demux",
+            cast="boolean",
+            optional=True,
+            default=False,
+        )
+        return True
+
     def select_read(self, *args, **kw):
         return self.communicator.select_read(*args, **kw)
 
     def ask(self, cmd, *args, **kw):
-        resp = super(NGXController, self).ask(cmd, *args, **kw)
-        if any(
-            (cmd.startswith(t) for t in ("GetValveStatus", "OpenValve", "CloseValve"))
-        ):
-            if resp and resp.strip() not in ("E00", "OPEN", "CLOSED"):
-                # if resp.strip()=='E04':
-                #     time.sleep(3)
-                #     return "OPEN\r\n"
-                # self.event_buf.push(resp)
-                self.debug("retrying")
+        resp = self._ask(cmd, *args, **kw)
+        if any((cmd.startswith(t) for t in VALVE_COMMANDS)):
+            # the instrument pushes #EVENT lines on the same stream; without
+            # demultiplexing an event line can arrive in place of the valve
+            # response, so retry a bounded number of times
+            for i in range(self.max_valve_retries):
+                if resp is None or resp.strip() in VALVE_RESPONSES:
+                    break
+                self.debug(f"retrying valve command {cmd} (attempt {i + 1}, got {resp.strip()})")
                 time.sleep(0.5)
-                return self.ask(cmd, *args, **kw)
+                resp = self._ask(cmd, *args, **kw)
+
+            if resp is not None and resp.strip() not in VALVE_RESPONSES:
+                self.warning(
+                    f"valve command {cmd} failed to return a valid response "
+                    f"after {self.max_valve_retries} retries: {resp.strip()}"
+                )
 
         return resp
 
-    # def read(self, *args, **kw):
-    #    if self.event_buffer.empty():
-    #        resp = super(NGXController, self).read(*args, **kw)
-    #    else:
-    #        resp = self.event_buffer.get()
-    #    return resp
+    def _ask(self, cmd, *args, **kw):
+        demux = self._demux
+        if demux is not None and demux.running:
+            timeout = kw.get("timeout") or self.communicator.timeout or 3
+            payload = f"{cmd}{self.communicator.write_terminator}"
+            resp = demux.ask(payload, timeout=timeout)
+            if kw.get("verbose", True):
+                self.communicator.log_response(payload, resp)
+            return resp
+
+        return super(NGXController, self).ask(cmd, *args, **kw)
+
+    def read_event(self, timeout=1.0):
+        """Next asynchronous #EVENT line, or None. Only available with demux."""
+        demux = self._demux
+        if demux is not None and demux.running:
+            return demux.get_event(timeout=timeout)
+
+    def has_demux(self):
+        demux = self._demux
+        return demux is not None and demux.running
 
     def set_acquisition_buffer(self, flag):
         flag = "1" if flag else "0"
@@ -89,7 +122,6 @@ class NGXController(CoreDevice):
         self.ask("StopAcq")
         self.canceled = True
         time.sleep(0.25)
-        # self.debug(self.communicator.readline())
 
     def clear_canceled(self):
         self.canceled = False
@@ -99,24 +131,76 @@ class NGXController(CoreDevice):
 
     def initialize(self, *args, **kw):
         ret = super(NGXController, self).initialize(*args, **kw)
+        if not ret:
+            return False
 
         self.communicator.strip = False
-        # trying a new locking mechanism see ngx.trigger for more details
-
         self.lock = Lock()
-        # self.lock = mRLock()
-        #   self.event_buffer = Queue()
 
-        if ret:
-            resp = self.communicator.readline()
-            self.debug("*********** initial response from NGX: {}".format(resp))
-            bind_preference(self, "username", "pychron.spectrometer.ngx.username")
-            bind_preference(self, "password", "pychron.spectrometer.ngx.password")
+        bind_preference(self, "username", "pychron.spectrometer.ngx.username")
+        bind_preference(self, "password", "pychron.spectrometer.ngx.password")
 
-            if resp:
-                self.info("NGX-{}".format(resp))
-                self.ask("Login {},{}".format(self.username, self.password))
-            return True
+        resp = self.communicator.readline()
+        self.debug(f"*********** initial response from NGX: {resp}")
+        if resp:
+            self.info(f"NGX-{resp}")
+            self.ask(f"Login {self.username},{self.password}")
+        else:
+            self.warning("no initial response from NGX; skipping Login")
+
+        # re-Login automatically whenever the communicator reconnects
+        self.communicator.on_connect = self._handle_connect
+
+        if self.use_demux:
+            self._start_demux()
+
+        return True
+
+    # private
+    def _handle_connect(self, handler):
+        """Session setup on a fresh connection (called from the communicator).
+
+        Writes directly to the handler: using ask() here would re-enter the
+        communicator and, with use_end set, tear down the connection that is
+        being established.
+        """
+        if not self.username:
+            return
+        self.debug("re-establishing NGX session (Login)")
+        try:
+            handler.send_packet(
+                f"Login {self.username},{self.password}{self.communicator.write_terminator}"
+            )
+            # consume the login response so it is not mistaken for the
+            # response to the command that triggered the reconnect
+            handler.readline(NGX_TERMINATOR.encode("utf-8"))
+        except (socket.error, OSError) as e:
+            self.warning(f"NGX re-login failed: {e}")
+
+    def _start_demux(self):
+        handler = self.communicator.get_handler()
+        if handler is None:
+            self.warning("cannot start NGX demux; no connection")
+            return
+
+        self._demux = LineDemultiplexer(
+            handler,
+            terminator=NGX_TERMINATOR,
+            event_prefix="#EVENT",
+            warning=self.warning,
+            on_reconnect=self._demux_reconnect,
+        )
+        self._demux.start()
+        self.info("NGX line demultiplexer started")
+
+    def _demux_reconnect(self):
+        """Build a fresh handler for the demux reader thread after a drop."""
+        comm = self.communicator
+        with comm.lock:
+            comm.reset()
+            handler = comm.get_handler()
+        # get_handler fires on_connect, which re-Logins on the new handler
+        return handler
 
 
 # ============= EOF =============================================

--- a/pychron/hardware/tests/ngx_controller_test.py
+++ b/pychron/hardware/tests/ngx_controller_test.py
@@ -1,0 +1,117 @@
+import unittest
+from typing import Optional
+from unittest import mock
+
+_IMPORT_ERROR: Optional[ModuleNotFoundError] = None
+try:
+    from pychron.hardware.isotopx_spectrometer_controller import NGXController
+except ModuleNotFoundError as exc:
+    NGXController = None  # type: ignore[assignment, misc]
+    _IMPORT_ERROR = exc
+
+
+class _FakeHandler:
+    def __init__(self, lines=None):
+        self.sent = []
+        self.lines = list(lines or [])
+
+    def send_packet(self, payload):
+        self.sent.append(payload)
+
+    def readline(self, terminator):
+        if self.lines:
+            return self.lines.pop(0)
+        return None
+
+
+@unittest.skipIf(_IMPORT_ERROR is not None, "Traits stack not available")
+class NGXControllerValveRetryTestCase(unittest.TestCase):
+    def _make_controller(self, responses):
+        controller = NGXController(name="ngx")
+        warnings = []
+        controller.warning = lambda msg: warnings.append(msg)
+        controller.debug = lambda msg: None
+        asks = []
+
+        def fake_ask(cmd, *args, **kw):
+            asks.append(cmd)
+            return responses.pop(0) if responses else None
+
+        controller._ask = fake_ask
+        return controller, asks, warnings
+
+    def test_valve_command_retries_until_valid(self):
+        controller, asks, warnings = self._make_controller(
+            ["#EVENT:ACQ,junk", "#EVENT:ACQ,junk", "OPEN"]
+        )
+
+        with mock.patch("pychron.hardware.isotopx_spectrometer_controller.time.sleep"):
+            resp = controller.ask("GetValveStatus V1")
+
+        self.assertEqual(resp, "OPEN")
+        self.assertEqual(len(asks), 3)
+        self.assertEqual(warnings, [])
+
+    def test_valve_command_retries_are_bounded(self):
+        controller, asks, warnings = self._make_controller(["junk"] * 10)
+
+        with mock.patch("pychron.hardware.isotopx_spectrometer_controller.time.sleep"):
+            resp = controller.ask("OpenValve V1")
+
+        # initial attempt + max_valve_retries
+        self.assertEqual(len(asks), 1 + controller.max_valve_retries)
+        self.assertEqual(resp, "junk")
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("failed to return a valid response", warnings[0])
+
+    def test_non_valve_command_does_not_retry(self):
+        controller, asks, warnings = self._make_controller(["#EVENT:ACQ,junk"])
+
+        resp = controller.ask("GETMASS")
+
+        self.assertEqual(len(asks), 1)
+        self.assertEqual(resp, "#EVENT:ACQ,junk")
+        self.assertEqual(warnings, [])
+
+    def test_none_response_does_not_retry(self):
+        controller, asks, warnings = self._make_controller([None])
+
+        with mock.patch("pychron.hardware.isotopx_spectrometer_controller.time.sleep"):
+            resp = controller.ask("CloseValve V1")
+
+        self.assertIsNone(resp)
+        self.assertEqual(len(asks), 1)
+
+
+@unittest.skipIf(_IMPORT_ERROR is not None, "Traits stack not available")
+class NGXControllerSessionTestCase(unittest.TestCase):
+    def test_handle_connect_sends_login_and_consumes_response(self):
+        controller = NGXController(name="ngx")
+        controller.username = "user"
+        controller.password = "pw"
+        controller.debug = lambda msg: None
+
+        class _Comm:
+            write_terminator = "\r"
+
+        controller._communicator = _Comm()
+        controller.communicator = _Comm()
+        handler = _FakeHandler(lines=["E00#\r\n"])
+
+        controller._handle_connect(handler)
+
+        self.assertEqual(handler.sent, ["Login user,pw\r"])
+        self.assertEqual(handler.lines, [])
+
+    def test_handle_connect_skips_without_credentials(self):
+        controller = NGXController(name="ngx")
+        controller.username = ""
+        handler = _FakeHandler()
+
+        controller._handle_connect(handler)
+
+        self.assertEqual(handler.sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/spectrometer/isotopx/spectrometer/ngx.py
+++ b/pychron/spectrometer/isotopx/spectrometer/ngx.py
@@ -38,7 +38,7 @@ from pychron.core.codetools.inspection import caller
 
 class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
     # integration_time = Int
-    integration_times = List(ISOTOPX_INTEGRATION_TIMES)
+    integration_times = List(ISOTOPX_INTEGRATION_TIMES)  # type: ignore[arg-type, var-annotated]
 
     magnet_klass = NGXMagnet
     detector_klass = NGXDetector
@@ -140,9 +140,7 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
             self._reset_acquisition_progress()
             # return self.ask('StartAcq 1,{}'.format(self.rcs_id), verbose=verbose)
             self.total_acq_count = int(self.integration_time)
-            return self.ask(
-                "StartAcq {},{}".format(int(self.integration_time), self.rcs_id)
-            )
+            return self.ask("StartAcq {},{}".format(int(self.integration_time), self.rcs_id))
         return True
 
     def readline(self, verbose=False, timeout=None):
@@ -152,28 +150,29 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
         ds = ""
         if timeout is None:
             timeout = self._get_read_timeout()
+
+        use_demux = self.microcontroller.has_demux()
         while 1:
             if time.time() - st > timeout:
                 if verbose:
-                    self.debug("readline timeout. raw={}".format(ds))
+                    self.debug(f"readline timeout. raw={ds}")
                 return
 
             if not self._read_enabled:
-                # or self.microcontroller.canceled:
-                # self.microcontroller.canceled = False
                 self.debug("readline canceled")
                 return
 
-            try:
-                # ds += self.read(1)
-                # print(ds)
-                ds = self.microcontroller.communicator.readline("#\r\n")
-                # ds = self.microcontroller.communicator.select_read(terminator="#\r\n")
-                # return ds
-            except BaseException:
-                if not self.microcontroller.canceled:
-                    self.debug_exception()
-                    self.debug(f"data left: {ds}")
+            if use_demux:
+                # events arrive pre-routed from the reader thread; command
+                # responses never appear here
+                ds = self.microcontroller.read_event(timeout=min(1.0, timeout))
+            else:
+                try:
+                    ds = self.microcontroller.communicator.readline("#\r\n")
+                except BaseException:
+                    if not self.microcontroller.canceled:
+                        self.debug_exception()
+                        self.debug(f"data left: {ds}")
 
             if ds and ds.endswith("#\r\n"):
                 return ds[:-3]
@@ -249,9 +248,7 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
                         break
                     continue
 
-                signals, keys = self._filter_signals_for_event(
-                    parsed["kind"], parsed["signals"]
-                )
+                signals, keys = self._filter_signals_for_event(parsed["kind"], parsed["signals"])
                 if signals is None:
                     continue
 
@@ -276,19 +273,15 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
                 self._reset_incomplete_acquisition()
 
         if len(signals) != len(keys):
-            self.debug("keys={}".format(keys))
-            self.debug("signals".format(signals))
-            self.debug(
-                "Number of signals {} and keys {} did not match".format(
-                    len(signals), len(keys)
-                )
-            )
+            self.debug(f"keys={keys}")
+            self.debug(f"signals={signals}")
+            self.debug(f"Number of signals {len(signals)} and keys {len(keys)} did not match")
             keys, signals = [], []
 
         if verbose:
-            self.debug("collection time: {}".format(collection_time))
-            self.debug("keys: {}".format(keys))
-            self.debug("signals: {}".format(signals))
+            self.debug(f"collection time: {collection_time}")
+            self.debug(f"keys: {keys}")
+            self.debug(f"signals: {signals}")
 
         return keys, signals, collection_time, inc
 
@@ -421,9 +414,7 @@ class NGXSpectrometer(BaseSpectrometer, IsotopxMixin):
         :param force: set integration even if "it" is not different than self.integration_time
         :return: float, integration time
         """
-        self.debug(
-            "acquisition period set to 1 second.  integration time set to {}".format(it)
-        )
+        self.debug("acquisition period set to 1 second.  integration time set to {}".format(it))
         # self.ask("StopAcq")
         self.microcontroller.stop_acquisition()
         self.ask("SetAcqPeriod 1000")


### PR DESCRIPTION
## Summary

Robustness work for Isotopx NGX communications, which multiplex async `#EVENT` pushes and command responses on one TCP stream.

- **`LineDemultiplexer`** (new, `pychron/hardware/core/communicators/line_demultiplexer.py`): a daemon reader thread owns all socket reads, splitting the stream on `#\r\n` and routing `#EVENT*` lines to an event queue, everything else to a response queue. `ask()` pairs each write with the next response line (stale responses drained first); acquisition consumes the event queue. Handles peer-close detection and reconnects via callback. **Opt-in** via `use_demux` in the device config `Communications` section — default path unchanged until validated on hardware.
- **Automatic re-Login on reconnect**: `EthernetCommunicator` gains an `on_connect` hook (fired with the fresh handler, reentrancy-guarded); `NGXController` replays `Login` through it and consumes the response. Previously Login was sent once at initialize, so any silent reconnect left an unauthenticated session and every later command failed.
- **Bounded valve retry**: the `GetValveStatus/OpenValve/CloseValve` retry was unbounded recursion (wedged instrument → infinite 0.5s loop, growing stack). Now capped at `max_valve_retries` (3) with a warning on exhaustion.
- **Partial lines survive timeouts**: `Handler._recvall` stashes accumulated bytes when `recv` times out and resumes on the next call, so an event line split by a timeout is no longer discarded.
- `NGXController.initialize` returns an explicit bool and warns when the NGX banner is missing instead of silently skipping Login.
- Fixed a real debug bug in `ngx.py`: `"signals".format(signals)` dropped its argument. Touched formatting converted to f-strings per AGENTS.md; pre-existing MyPy errors in changed files resolved.

## Context

- Follows the NGX comms analysis: every observed failure symptom (valve retry hack, deliberately disabled acquisition locking, stale-event compensation) traces to the missing demultiplexing layer; the silent unauthenticated-reconnect was the worst field failure mode.
- Stacked on #37 (base `fix/ethernet-comms`); retargets to `main` when #37 merges. CI will not run until then (workflow only triggers on PRs targeting main/develop/dev/hot/release) — verified locally.

## Verification

- [x] Tests added or updated where appropriate
- [x] Local verification completed
- [x] CI is expected to pass

Verification details:

- 7 new `LineDemultiplexer` tests: event/response routing, stale-response drain, ask timeout, events never satisfy ask, reconnect after peer close, stop, clear_events
- 6 new `NGXController` tests: valve retry until valid, retry bound + warning, non-valve no-retry, None no-retry, re-Login on connect (sends + consumes response), skip without credentials
- 2 new communicator tests: partial-line preservation across timeout, on_connect fires once with reentrancy guard
- `pychron/hardware` suite: 282 tests OK; `pychron/hardware/core`: 116 OK; Black + MyPy clean on all changed files

## Risk

- Default behavior: low — demux is opt-in; non-demux changes are the bounded retry (strictly safer than unbounded recursion), partial-line stash (only affects the previously-discarding timeout path), and re-Login hook (no-op until credentials bound).
- Demux path: needs validation on a hardware-connected system before enabling in production configs. Suggested rollout: enable `use_demux=True` on a test bench, run scan + automated run concurrently with valve actuation.

## Target Branch Check

- [x] This PR targets the branch it was created from logically (`develop`, the active `dev/*` stream, `release/*`, or `hotfix/*`) — stacked on `fix/ethernet-comms` (#37)

## Follow-ups

- Hardware validation of the demux path, then flip `use_demux` default
- Heartbeat (periodic GETMASS when idle) wired into the existing health callbacks for proactive reconnect
- Once demux is default, remove the stale-event compensation machinery and the valve retry entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)