### PR TITLE
fix(experiment): repair py3 imports in image_browser and make_runid chain

### DIFF
--- a/pychron/database/isotope_database_manager.py
+++ b/pychron/database/isotope_database_manager.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import typing
 import weakref
 
 # ============= standard library imports ========================
@@ -37,12 +38,12 @@ from pychron.core.i_datastore import IDatastore
 from pychron.core.progress import progress_loader, CancelLoadingError
 from pychron.database.adapters.isotope_adapter import IsotopeAdapter
 from pychron.database.orms.isotope.meas import meas_AnalysisTable
-from pychron.experiment.utilities.identifier import make_runid
+from pychron.experiment.utilities.runid import make_runid
 from pychron.loggable import Loggable
 from pychron.processing.analyses.dbanalysis import DBAnalysis
 
-ANALYSIS_CACHE = {}
-ANALYSIS_CACHE_COUNT = {}
+ANALYSIS_CACHE: dict[str, typing.Any] = {}
+ANALYSIS_CACHE_COUNT: dict[str, int] = {}
 CACHE_LIMIT = 1000
 
 
@@ -61,7 +62,7 @@ class BaseIsotopeDatabaseManager(Loggable):
         version_warn=False,
         attribute_warn=False,
         *args,
-        **kw
+        **kw,
     ):
         super(BaseIsotopeDatabaseManager, self).__init__(*args, **kw)
 
@@ -74,9 +75,7 @@ class BaseIsotopeDatabaseManager(Loggable):
                 traceback.print_exc()
 
         if connect:
-            self.db.connect(
-                warn=warn, version_warn=version_warn, attribute_warn=attribute_warn
-            )
+            self.db.connect(warn=warn, version_warn=version_warn, attribute_warn=attribute_warn)
 
     # IDatastore protocol
     def get_greatest_aliquot(self, identifier):
@@ -136,9 +135,7 @@ class BaseIsotopeDatabaseManager(Loggable):
     def _open_progress(self, n, close_at_end=True):
         from pychron.core.ui.progress_dialog import myProgressDialog
 
-        pd = myProgressDialog(
-            max=n - 1, close_at_end=close_at_end, can_cancel=True, can_ok=True
-        )
+        pd = myProgressDialog(max=n - 1, close_at_end=close_at_end, can_cancel=True, can_ok=True)
         pd.open()
         # pd.on_trait_change(self._progress_closed, 'closed')
         return pd
@@ -313,7 +310,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
         calculate_age=False,
         calculate_F=False,
         load_aux=False,
-        **kw
+        **kw,
     ):
         """
         loading the analysis' signals appears to be the most expensive operation.
@@ -329,9 +326,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
         db = self.db
         with db.session_ctx():
             # partition into DBAnalysis vs IsotopeRecordView
-            db_ans, no_db_ans = list(
-                map(list, partition(ans, lambda x: isinstance(x, DBAnalysis)))
-            )
+            db_ans, no_db_ans = list(map(list, partition(ans, lambda x: isinstance(x, DBAnalysis))))
             self._calculate_cached_ages(db_ans, calculate_age, calculate_F)
             if unpack:
                 for di in db_ans:
@@ -349,9 +344,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
             if no_db_ans:
                 if use_cache:
                     # partition into cached and non cached analyses
-                    cached_ans, no_db_ans = partition(
-                        no_db_ans, lambda x: x.uuid in ANALYSIS_CACHE
-                    )
+                    cached_ans, no_db_ans = partition(no_db_ans, lambda x: x.uuid in ANALYSIS_CACHE)
                     cached_ans = list(cached_ans)
                     no_db_ans = list(no_db_ans)
 
@@ -360,9 +353,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
                     # if unpack is true make sure cached analyses have raw data
                     if unpack or load_aux:
                         if unpack:
-                            a, b = self._unpack_cached_analyses(
-                                cns, calculate_age, calculate_F
-                            )
+                            a, b = self._unpack_cached_analyses(cns, calculate_age, calculate_F)
                             db_ans.extend(a)
                             no_db_ans.extend(b)
                         if load_aux:
@@ -392,7 +383,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
                         use_cache,
                         use_progress,
                         load_aux=load_aux,
-                        **kw
+                        **kw,
                     )
                     db_ans.extend(new_ans)
 
@@ -456,7 +447,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
         unpack,
         use_cache,
         use_progress,
-        **kw
+        **kw,
     ):
         uuids = [ri.uuid for ri in no_db_ans]
         # for ui in uuids:
@@ -484,7 +475,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
                 unpack=unpack,
                 calculate_age=calculate_age,
                 calculate_F=calculate_F,
-                **kw
+                **kw,
             )
             # print a
             if use_cache:
@@ -603,11 +594,7 @@ class IsotopeDatabaseManager(BaseIsotopeDatabaseManager):
             k, v = s[0]
             ANALYSIS_CACHE.pop(k)
             ANALYSIS_CACHE_COUNT.pop(k)
-            self.debug(
-                "Cache limit exceeded {}. removing {} n uses={}".format(
-                    CACHE_LIMIT, k, v
-                )
-            )
+            self.debug("Cache limit exceeded {}. removing {} n uses={}".format(CACHE_LIMIT, k, v))
 
     # ===============================================================================
     # property get/set

--- a/pychron/database/orms/isotope/meas.py
+++ b/pychron/database/orms/isotope/meas.py
@@ -36,7 +36,7 @@ from sqlalchemy.sql.expression import func
 
 from pychron.database.core.base_orm import BaseMixin, NameMixin, UserMixin
 from pychron.database.orms.isotope.util import foreignkey, stringcolumn
-from pychron.experiment.utilities.identifier import make_runid
+from pychron.experiment.utilities.runid import make_runid
 from .util import Base
 
 
@@ -74,9 +74,7 @@ class meas_AnalysisTable(Base, BaseMixin):
         # lazy='dynamic',
         backref="analysis",
     )
-    peak_center = relationship(
-        "meas_PeakCenterTable", backref="analysis", uselist=False
-    )
+    peak_center = relationship("meas_PeakCenterTable", backref="analysis", uselist=False)
 
     # proc relationships
     blanks_histories = relationship("proc_BlanksHistoryTable", backref="analysis")
@@ -84,13 +82,9 @@ class meas_AnalysisTable(Base, BaseMixin):
     blanks_values = relationship("proc_BlanksSetValueTable", backref="analysis")
     preceding_blanks = relationship("proc_BlanksTable", backref="preceding_analysis")
 
-    interpreted_age_sets = relationship(
-        "proc_InterpretedAgeSetTable", backref="analysis"
-    )
+    interpreted_age_sets = relationship("proc_InterpretedAgeSetTable", backref="analysis")
 
-    backgrounds_histories = relationship(
-        "proc_BackgroundsHistoryTable", backref="analysis"
-    )
+    backgrounds_histories = relationship("proc_BackgroundsHistoryTable", backref="analysis")
     backgrounds_sets = relationship("proc_BackgroundsSetTable", backref="analysis")
 
     detector_intercalibration_histories = relationship(
@@ -100,9 +94,7 @@ class meas_AnalysisTable(Base, BaseMixin):
         "proc_DetectorIntercalibrationSetTable", backref="analysis"
     )
 
-    detector_param_histories = relationship(
-        "proc_DetectorParamHistoryTable", backref="analysis"
-    )
+    detector_param_histories = relationship("proc_DetectorParamHistoryTable", backref="analysis")
 
     fit_histories = relationship("proc_FitHistoryTable", backref="analysis")
 
@@ -208,9 +200,7 @@ class meas_SpectrometerParametersTable(Base, BaseMixin):
     zsymmetry = Column(Float)
     zfocus = Column(Float)
     hash = Column(String(32))
-    measurements = relationship(
-        "meas_MeasurementTable", backref="spectrometer_parameters"
-    )
+    measurements = relationship("meas_MeasurementTable", backref="spectrometer_parameters")
 
 
 class meas_SpectrometerDeflectionsTable(Base, BaseMixin):
@@ -244,9 +234,7 @@ class meas_MeasurementTable(Base, BaseMixin):
     #                                         uselist=False
     #                                         )
     analyses = relationship("meas_AnalysisTable", backref="measurement")
-    deflections = relationship(
-        "meas_SpectrometerDeflectionsTable", backref="measurement"
-    )
+    deflections = relationship("meas_SpectrometerDeflectionsTable", backref="measurement")
 
 
 class meas_PeakCenterTable(Base, BaseMixin):

--- a/pychron/database/orms/isotope/proc.py
+++ b/pychron/database/orms/isotope/proc.py
@@ -35,7 +35,7 @@ from sqlalchemy.sql.expression import func
 
 from pychron.database.core.base_orm import BaseMixin, NameMixin
 from pychron.database.orms.isotope.util import foreignkey, stringcolumn
-from pychron.experiment.utilities.identifier import make_runid
+from pychron.experiment.utilities.runid import make_runid
 from pychron.pychron_constants import INTERPOLATE_TYPES
 from .util import Base
 
@@ -82,9 +82,7 @@ class proc_AnalysisGroupSetTable(Base, BaseMixin):
 
 
 class proc_SensitivityHistoryTable(Base, HistoryMixin):
-    sensitivity = relationship(
-        "proc_SensitivityTable", backref="history", uselist=False
-    )
+    sensitivity = relationship("proc_SensitivityTable", backref="history", uselist=False)
     selected = relationship(
         "proc_SelectedHistoriesTable", backref="selected_sensitivity", uselist=False
     )
@@ -118,9 +116,7 @@ class proc_TagTable(Base):
 
 class proc_ArArHistoryTable(Base, HistoryMixin):
     arar_result = relationship("proc_ArArTable", backref="history", uselist=False)
-    selected = relationship(
-        "proc_SelectedHistoriesTable", backref="selected_arar", uselist=False
-    )
+    selected = relationship("proc_SelectedHistoriesTable", backref="selected_arar", uselist=False)
 
 
 class proc_ArArTable(Base, BaseMixin):
@@ -176,13 +172,9 @@ class proc_InterpretedAgeHistoryTable(Base, BaseMixin):
     create_date = Column(DateTime, default=func.now())
     user = stringcolumn()
 
-    interpreted_age = relationship(
-        "proc_InterpretedAgeTable", backref="history", uselist=False
-    )
+    interpreted_age = relationship("proc_InterpretedAgeTable", backref="history", uselist=False)
     identifier = stringcolumn(80)
-    selected = relationship(
-        "gen_LabTable", backref="selected_interpreted_age", uselist=False
-    )
+    selected = relationship("gen_LabTable", backref="selected_interpreted_age", uselist=False)
 
     group_sets = relationship("proc_InterpretedAgeGroupSetTable", backref="history")
 
@@ -241,9 +233,7 @@ class proc_BlanksSetTable(Base, BaseMixin):
 class proc_BlanksHistoryTable(Base, HistoryMixin):
     action_id = foreignkey("proc_ActionTable")
     blanks = relationship("proc_BlanksTable", backref="history")
-    selected = relationship(
-        "proc_SelectedHistoriesTable", backref="selected_blanks", uselist=False
-    )
+    selected = relationship("proc_SelectedHistoriesTable", backref="selected_blanks", uselist=False)
 
 
 class proc_BlanksTable(Base, BaseMixin):
@@ -349,9 +339,7 @@ class proc_DetectorIntercalibrationTable(Base, BaseMixin):
     fit = stringcolumn()
     error_type = stringcolumn(default="SD")
     # set_id = Column(Integer)
-    set_id = Column(
-        String(40), ForeignKey("proc_DetectorIntercalibrationSetTable.set_id")
-    )
+    set_id = Column(String(40), ForeignKey("proc_DetectorIntercalibrationSetTable.set_id"))
 
 
 class proc_DetectorParamHistoryTable(Base, HistoryMixin):
@@ -413,9 +401,7 @@ class proc_FitHistoryTable(Base, HistoryMixin):
     action_id = foreignkey("proc_ActionTable")
     fits = relationship("proc_FitTable", backref="history")
     results = relationship("proc_IsotopeResultsTable", backref="history")
-    selected = relationship(
-        "proc_SelectedHistoriesTable", backref="selected_fits", uselist=False
-    )
+    selected = relationship("proc_SelectedHistoriesTable", backref="selected_fits", uselist=False)
 
 
 class proc_FitTable(Base, BaseMixin):
@@ -456,9 +442,7 @@ class proc_SelectedHistoriesTable(Base, BaseMixin):
     selected_det_param_id = foreignkey("proc_DetectorParamHistoryTable")
     selected_sensitivity_id = foreignkey("proc_SensitivityHistoryTable")
 
-    dr_sets = relationship(
-        "proc_DataReductionTagSetTable", backref="selected_histories"
-    )
+    dr_sets = relationship("proc_DataReductionTagSetTable", backref="selected_histories")
 
 
 class proc_IsotopeResultsTable(Base, BaseMixin):

--- a/pychron/database/records/isotope_record.py
+++ b/pychron/database/records/isotope_record.py
@@ -25,7 +25,7 @@ from pychron.core.utils import alphas
 # ============= standard library imports ========================
 # import re
 # ============= local library imports  ==========================
-from pychron.experiment.utilities.identifier import make_runid
+from pychron.experiment.utilities.runid import make_runid
 
 
 def get_flux_fit_status(item):
@@ -162,9 +162,7 @@ class IsotopeRecordView(object):
             if irp is not None:
                 irl = irp.level
                 ir = irl.irradiation
-                self.irradiation_info = "{}{} {}".format(
-                    ir.name, irl.name, irp.position
-                )
+                self.irradiation_info = "{}{} {}".format(ir.name, irl.name, irp.position)
 
             try:
                 self.mass_spectrometer = dbrecord.mass_spectrometer
@@ -197,9 +195,7 @@ class IsotopeRecordView(object):
                 self.timestamp = time.mktime(self.rundate.timetuple())
                 if meas:
                     try:
-                        self.meas_script_name = self._clean_script_name(
-                            meas.script.name
-                        )
+                        self.meas_script_name = self._clean_script_name(meas.script.name)
                     except AttributeError as e:
                         pass
                         # print 'IsotopeRecord create meas 2 {}'.format(e)
@@ -208,9 +204,7 @@ class IsotopeRecordView(object):
 
                 if ext is not None:
                     try:
-                        self.extract_script_name = self._clean_script_name(
-                            ext.script.name
-                        )
+                        self.extract_script_name = self._clean_script_name(ext.script.name)
                     except AttributeError as e:
                         pass
                         # print 'IsotopeRecord create ext 1 {}'.format(e)
@@ -237,9 +231,7 @@ class IsotopeRecordView(object):
         return n
 
     def to_string(self):
-        return "{} {} {} {}".format(
-            self.identifier, self.aliquot, self.timestamp, self.uuid
-        )
+        return "{} {} {} {}".format(self.identifier, self.aliquot, self.timestamp, self.uuid)
 
     @property
     def record_id(self):

--- a/pychron/experiment/image_browser.py
+++ b/pychron/experiment/image_browser.py
@@ -15,8 +15,6 @@
 # ===============================================================================
 
 # ============= enthought library imports =======================
-from __future__ import absolute_import
-from __future__ import print_function
 from chaco.api import ArrayPlotData, Plot, HPlotContainer
 from chaco.tools.api import ZoomTool, PanTool
 from chaco.tools.image_inspector_tool import ImageInspectorOverlay, ImageInspectorTool
@@ -46,10 +44,11 @@ from traitsui.api import (
 )
 
 # ============= standard library imports ========================
-import Image
-from numpy import array
+import http.client
 import os
-import six.moves.http_client
+
+from numpy import array
+from PIL import Image
 
 # ============= local library imports  ==========================
 from pychron.core.ui.custom_label_editor import CustomLabel
@@ -134,9 +133,7 @@ class ImageEditor(HasTraits):
                 Item(
                     "names",
                     show_label=False,
-                    editor=ListStrEditor(
-                        editable=False, selected="selected", operations=[]
-                    ),
+                    editor=ListStrEditor(editable=False, selected="selected", operations=[]),
                     height=0.6,
                 ),
                 Item("image_spec", show_label=False, style="custom", height=0.4),
@@ -193,8 +190,8 @@ class ImageBrowser(IsotopeDatabaseManager):
     def _connection_factory(self, reset=False):
         if reset or self._conn is None:
             host, port = "localhost", 8081
-            url = "{}:{}".format(host, port)
-            conn = six.moves.http_client.HTTPConnection(url)
+            url = f"{host}:{port}"
+            conn = http.client.HTTPConnection(url)
         else:
             conn = self._conn
 
@@ -229,9 +226,9 @@ class ImageBrowser(IsotopeDatabaseManager):
     #        return array(im)
 
     def _get_cached(self, name):
-        self.info("retrieve {} from cache directory".format(name))
+        self.info(f"retrieve {name} from cache directory")
         p = os.path.join(self.cache_dir, name)
-        with open(p, "r") as rfile:
+        with open(p, "rb") as rfile:
             im = Image.open(rfile)
             im = im.convert("RGB")
             return array(im)


### PR DESCRIPTION
## Summary

- Fix `pychron/experiment/image_browser.py` failing to import on Python 3: replace py2-era `import Image` with `from PIL import Image` (Pillow).
- Remove other py2 dead code in the file: `__future__` imports, `six.moves.http_client` (→ stdlib `http.client`), and text-mode `open(p, "r")` in `_get_cached` (→ `"rb"`, required for `Image.open`).
- Repair a stale import chain the fix exposed: four database modules imported `make_runid` from `pychron.experiment.utilities.identifier`, but it lives in `pychron.experiment.utilities.runid`. Repointed in `orms/isotope/meas.py`, `orms/isotope/proc.py`, `records/isotope_record.py`, and `isotope_database_manager.py`.
- Annotate `ANALYSIS_CACHE` / `ANALYSIS_CACHE_COUNT` in `isotope_database_manager.py` to satisfy the mypy gate on changed files.

## Context

- `image_browser.py` was unimportable on Python 3 (`ModuleNotFoundError: No module named 'Image'`) — historically unmaintained py2 code.
- Even with the PIL fix, the module still failed to import because its dependency chain (`isotope_database_manager` → `isotope_adapter` → ORM modules) carried stale `make_runid` imports raising `ImportError`. Any consumer of those database modules was equally broken.

## Verification

- [ ] Tests added or updated where appropriate (no tests — import/formatting repair of legacy module)
- [x] Local verification completed
- [x] CI is expected to pass

Verification details:

- `uv run python -c "import pychron.experiment.image_browser"` → ok (also imports all four repaired database modules transitively; verified each explicitly as well)
- `uv run --no-sync mypy --explicit-package-bases <5 changed files>` → no issues
- `uv run black --check <5 changed files>` → clean (4 files had pre-existing drift at line_length 100; black applied since CI checks changed files — explains most of the diff, all mechanical line-joins)

## Risk

- Low. Import-path and formatting changes only; no logic changes. The `"r"` → `"rb"` change in `_get_cached` fixes behavior that could not have worked on py3.
- Overlaps with open #43 (repo-wide six/`__future__` removal) — small, trivial merge conflict possible in `image_browser.py`.

## Target Branch Check

- [x] This PR targets the branch it was created from logically (`main`)

## Follow-ups

- Pre-existing dead code left untouched: `ImageBrowser.load_remote_directory` calls `self._get()`, which is commented out — `AttributeError` at runtime if used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)