### PR TITLE
refactor(hardware): replace device comm mixins with composition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,8 @@ jobs:
             pychron.core.tests.import_hygiene_test \
             pychron.experiment.tests.queue_metadata \
             pychron.experiment.tests.pyscript_integration
+
+      - name: Run hardware tests
+        run: |
+          xvfb-run -a uv run --no-sync python -m unittest discover \
+            -s pychron/hardware -p "*test*.py"

--- a/pychron/hardware/core/tests/communication_strategy_test.py
+++ b/pychron/hardware/core/tests/communication_strategy_test.py
@@ -1,0 +1,196 @@
+import unittest
+
+from pychron.hardware.pychron_device import (
+    SerialCommunicationStrategy,
+    EthernetCommunicationStrategy,
+)
+
+
+class _FakeCommunicator:
+    def __init__(self):
+        self.open_calls = []
+        self.reported = False
+        # serial attrs
+        self.port = None
+        self.baudrate = None
+        self.read_delay = None
+        self.parity = None
+        self.stopbits = None
+        # ethernet attrs
+        self.host = None
+        self.kind = None
+        self.use_end = None
+        self.message_frame = None
+        self.write_terminator = None
+        self.read_terminator = None
+        self.timeout = None
+
+    def set_parity(self, v):
+        self.parity = v
+
+    def set_stopbits(self, v):
+        self.stopbits = v
+
+    def open(self, **kw):
+        self.open_calls.append(kw)
+        return True
+
+    def report(self):
+        self.reported = True
+
+
+class _FakeDevice:
+    def __init__(self, communicator=None, build_result=None):
+        self.communicator = communicator
+        self._build_result = build_result if build_result is not None else _FakeCommunicator()
+        self.build_calls = []
+
+        # connection traits read by the strategies
+        self.port = 0
+        self.baudrate = 9600
+        self.read_delay = 25
+        self.parity = "N"
+        self.stopbits = "1"
+        self.host = "localhost"
+        self.kind = "FusionsCO2"
+        self.use_end = True
+        self.message_frame = "\n"
+        self.write_terminator = "\n"
+        self.read_terminator = ""
+        self.timeout = 3
+
+    def build_communicator(self, comtype):
+        self.build_calls.append(comtype)
+        self.communicator = self._build_result
+        return self._build_result
+
+
+class SerialCommunicationStrategyTestCase(unittest.TestCase):
+    def test_builds_serial_communicator(self):
+        device = _FakeDevice()
+        device.port = "COM1"
+
+        ret = SerialCommunicationStrategy().setup(device)
+
+        self.assertTrue(ret)
+        self.assertEqual(device.build_calls, ["serial"])
+
+    def test_configures_communicator_from_device_traits(self):
+        device = _FakeDevice()
+        device.port = "COM1"
+        device.baudrate = 19200
+        device.read_delay = 50
+        device.parity = "E"
+        device.stopbits = "2"
+
+        ec = device.build_communicator("serial")
+        device.build_calls = []
+        SerialCommunicationStrategy().setup(device)
+
+        self.assertEqual(ec.port, "COM1")
+        self.assertEqual(ec.baudrate, 19200)
+        self.assertEqual(ec.read_delay, 50)
+        self.assertEqual(ec.parity, "E")
+        self.assertEqual(ec.stopbits, "2")
+
+    def test_opens_with_timeout(self):
+        device = _FakeDevice()
+        device.timeout = 7
+
+        ec = device.build_communicator("serial")
+        SerialCommunicationStrategy().setup(device)
+
+        self.assertEqual(ec.open_calls, [{"timeout": 7}])
+
+    def test_returns_none_when_build_fails(self):
+        device = _FakeDevice()
+        device.build_communicator = lambda comtype: None
+
+        ret = SerialCommunicationStrategy().setup(device)
+
+        self.assertIsNone(ret)
+
+
+class EthernetCommunicationStrategyTestCase(unittest.TestCase):
+    def test_builds_ethernet_communicator_when_none(self):
+        device = _FakeDevice(communicator=None)
+
+        ret = EthernetCommunicationStrategy().setup(device)
+
+        self.assertTrue(ret)
+        self.assertEqual(device.build_calls, ["ethernet"])
+
+    def test_configures_communicator_from_device_traits(self):
+        device = _FakeDevice(communicator=None)
+        device.host = "192.168.0.5"
+        device.port = 8080
+        device.kind = "ArgusVI"
+        device.use_end = False
+        device.message_frame = "\r"
+        device.timeout = 9
+
+        ec = EthernetCommunicationStrategy().setup(device) and device.communicator
+
+        self.assertEqual(ec.host, "192.168.0.5")
+        self.assertEqual(ec.port, 8080)
+        self.assertEqual(ec.kind, "ArgusVI")
+        self.assertEqual(ec.use_end, False)
+        self.assertEqual(ec.message_frame, "\r")
+        self.assertEqual(ec.timeout, 9)
+
+    def test_terminator_override(self):
+        device = _FakeDevice(communicator=None)
+
+        EthernetCommunicationStrategy().setup(
+            device, write_terminator="\r\n", read_terminator="\r\n"
+        )
+
+        self.assertEqual(device.communicator.write_terminator, "\r\n")
+        self.assertEqual(device.communicator.read_terminator, "\r\n")
+
+    def test_terminator_defaults_from_device(self):
+        device = _FakeDevice(communicator=None)
+        device.write_terminator = "W"
+        device.read_terminator = "R"
+
+        EthernetCommunicationStrategy().setup(device)
+
+        self.assertEqual(device.communicator.write_terminator, "W")
+        self.assertEqual(device.communicator.read_terminator, "R")
+
+    def test_skips_build_when_already_connected(self):
+        existing = _FakeCommunicator()
+        device = _FakeDevice(communicator=existing)
+
+        ret = EthernetCommunicationStrategy().setup(device)
+
+        self.assertTrue(ret)
+        self.assertEqual(device.build_calls, [])
+        self.assertEqual(existing.open_calls, [])
+
+    def test_force_rebuilds_when_already_connected(self):
+        existing = _FakeCommunicator()
+        device = _FakeDevice(communicator=existing)
+
+        EthernetCommunicationStrategy().setup(device, force=True)
+
+        self.assertEqual(device.build_calls, ["ethernet"])
+
+    def test_reports_after_open(self):
+        device = _FakeDevice(communicator=None)
+
+        EthernetCommunicationStrategy().setup(device)
+
+        self.assertTrue(device.communicator.reported)
+
+    def test_returns_none_when_build_fails(self):
+        device = _FakeDevice(communicator=None)
+        device.build_communicator = lambda comtype: None
+
+        ret = EthernetCommunicationStrategy().setup(device)
+
+        self.assertIsNone(ret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/hardware/pychron_device.py
+++ b/pychron/hardware/pychron_device.py
@@ -23,6 +23,61 @@ from pychron.has_communicator import HasCommunicator
 from pychron.loggable import Loggable
 
 
+class CommunicationStrategy:
+    """
+    Configures a device's communicator for a particular transport.
+
+    Strategies are stateless: they operate on the ``device`` passed to
+    ``setup``, reading the connection traits (port, host, baudrate, ...) the
+    device defines. This is the composition replacement for the former
+    ``SerialDeviceMixin`` / ``EthernetDeviceMixin`` inheritance.
+    """
+
+    def setup(self, device, **kw):
+        raise NotImplementedError
+
+
+class SerialCommunicationStrategy(CommunicationStrategy):
+    def setup(self, device, **kw):
+        ec = device.build_communicator("serial")
+        if ec is None:
+            return
+        ec.port = device.port
+        ec.baudrate = device.baudrate
+        ec.read_delay = device.read_delay
+        ec.set_parity(device.parity)
+        ec.set_stopbits(device.stopbits)
+        return ec.open(timeout=device.timeout)
+
+
+class EthernetCommunicationStrategy(CommunicationStrategy):
+    def setup(self, device, write_terminator=None, read_terminator=None, force=False):
+        if write_terminator is None:
+            write_terminator = device.write_terminator
+
+        if read_terminator is None:
+            read_terminator = device.read_terminator
+
+        ret = True
+        if force or device.communicator is None:
+            ec = device.build_communicator("ethernet")
+            if ec is None:
+                return
+            ec.host = device.host
+            ec.port = device.port
+            ec.kind = device.kind
+            ec.use_end = device.use_end
+            ec.message_frame = device.message_frame
+            ec.write_terminator = write_terminator
+            ec.read_terminator = read_terminator
+            ec.timeout = device.timeout
+            ret = ec.open()
+            if device.communicator:
+                device.communicator.report()
+
+        return ret
+
+
 class RemoteDeviceMixin(Loggable, HasCommunicator):
     connected = False
 
@@ -33,6 +88,10 @@ class RemoteDeviceMixin(Loggable, HasCommunicator):
     write_terminator = chr(10)
     read_terminator = ""
 
+    # transport behavior is composed, not inherited. Set to a
+    # CommunicationStrategy instance by the concrete device class.
+    communication_strategy = None
+
     def open(self):
         return self.setup_communicator()
 
@@ -42,8 +101,10 @@ class RemoteDeviceMixin(Loggable, HasCommunicator):
     def shutdown(self):
         self.close_communicator()
 
-    def setup_communicator(self):
-        raise NotImplementedError
+    def setup_communicator(self, *args, **kw):
+        if self.communication_strategy is None:
+            raise NotImplementedError
+        return self.communication_strategy.setup(self, *args, **kw)
 
     def _ask(self, *args, **kw):
         if not self.communicator:
@@ -51,59 +112,6 @@ class RemoteDeviceMixin(Loggable, HasCommunicator):
 
         if self.communicator:
             return self.communicator.ask(*args, **kw)
-
-
-class SerialDeviceMixin(RemoteDeviceMixin):
-    port = Str
-    baudrate = CInt
-    parity = Str
-    stopbits = Str
-    read_delay = CInt
-
-    def setup_communicator(self):
-        ec = self.build_communicator("serial")
-        if ec is None:
-            return
-        ec.port = self.port
-        ec.baudrate = self.baudrate
-        ec.read_delay = self.read_delay
-        ec.set_parity(self.parity)
-        ec.set_stopbits(self.stopbits)
-        return ec.open(timeout=self.timeout)
-
-
-class EthernetDeviceMixin(RemoteDeviceMixin):
-    port = CInt
-    host = Str
-    timeout = CInt
-
-    def setup_communicator(
-        self, write_terminator=None, read_terminator=None, force=False
-    ):
-        if write_terminator is None:
-            write_terminator = self.write_terminator
-
-        if read_terminator is None:
-            read_terminator = self.read_terminator
-
-        ret = True
-        if force or self.communicator is None:
-            ec = self.build_communicator("ethernet")
-            if ec is None:
-                return
-            ec.host = self.host
-            ec.port = self.port
-            ec.kind = self.kind
-            ec.use_end = self.use_end
-            ec.message_frame = self.message_frame
-            ec.write_terminator = write_terminator
-            ec.read_terminator = read_terminator
-            ec.timeout = self.timeout
-            ret = ec.open()
-            if self.communicator:
-                self.communicator.report()
-
-        return ret
 
 
 # ============= EOF =============================================

--- a/pychron/lasers/laser_managers/ethernet_laser_manager.py
+++ b/pychron/lasers/laser_managers/ethernet_laser_manager.py
@@ -14,13 +14,24 @@
 # limitations under the License.
 # ===============================================================================
 
-from pychron.hardware.pychron_device import EthernetDeviceMixin
+from traits.api import Str, CInt
+
+from pychron.hardware.pychron_device import (
+    RemoteDeviceMixin,
+    EthernetCommunicationStrategy,
+)
 from pychron.lasers.laser_managers.remote_laser_manager import RemoteLaserManager
 
 
-class EthernetLaserManager(RemoteLaserManager, EthernetDeviceMixin):
+class EthernetLaserManager(RemoteLaserManager, RemoteDeviceMixin):
+    port = CInt
+    host = Str
+    timeout = CInt
+
+    communication_strategy = EthernetCommunicationStrategy()
+
     def open(self, *args, **kw):
-        return EthernetDeviceMixin.open(self)
+        return RemoteDeviceMixin.open(self)
 
     def _test_connection_hook(self):
         r = self.opened()

--- a/pychron/lasers/laser_managers/serial_laser_manager.py
+++ b/pychron/lasers/laser_managers/serial_laser_manager.py
@@ -13,13 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from pychron.hardware.pychron_device import SerialDeviceMixin
+from traits.api import Str, CInt
+
+from pychron.hardware.pychron_device import (
+    RemoteDeviceMixin,
+    SerialCommunicationStrategy,
+)
 from pychron.lasers.laser_managers.remote_laser_manager import RemoteLaserManager
 
 
-class SerialLaserManager(RemoteLaserManager, SerialDeviceMixin):
+class SerialLaserManager(RemoteLaserManager, RemoteDeviceMixin):
+    port = Str
+    baudrate = CInt
+    parity = Str
+    stopbits = Str
+    read_delay = CInt
+
+    communication_strategy = SerialCommunicationStrategy()
+
     def open(self, *args, **kw):
-        return SerialDeviceMixin.open(self)
+        return RemoteDeviceMixin.open(self)
 
 
 # ============= EOF =============================================


### PR DESCRIPTION
## Summary

`SerialDeviceMixin` and `EthernetDeviceMixin` differed in exactly **one method** — `setup_communicator`. Classic composition-over-inheritance smell: transport baked into type identity.

Replaced with the Strategy pattern:
- New stateless `CommunicationStrategy` base + `SerialCommunicationStrategy` / `EthernetCommunicationStrategy` in `pychron_device.py`. Each operates on the `device` passed to `setup(...)`.
- `RemoteDeviceMixin` keeps the shared comm traits/methods and gains a composed `communication_strategy`; `setup_communicator(*args, **kw)` delegates to it.
- Deleted `SerialDeviceMixin` / `EthernetDeviceMixin`. The two users (`SerialLaserManager`, `EthernetLaserManager`) now declare their own transport traits (resolves the `port=Str` vs `port=CInt` collision) and set a strategy instance.

Net: one inheritance axis removed; transport setup is now a swappable, independently testable object. `ChromiumLaserManager`'s `super().setup_communicator(write_terminator=..., read_terminator=...)` override path preserved through delegation.

## Tests

- New `pychron/hardware/core/tests/communication_strategy_test.py` (12 cases) — mirrors existing `has_communicator_test` style, no hardware/traits harness. Covers build, trait config, timeout, terminator override/defaults, skip-when-connected, force-reconnect, report, build-failure for both strategies.
- CI: added a **Run hardware tests** step using `unittest discover -s pychron/hardware` — picks up all 282 hardware tests (incl. this one) and future additions automatically.

## Verification

- `py_compile` on all touched + dependent laser-manager files: OK.
- Full hardware discovery locally: **282 tests, OK**.
- Black: passed (pre-commit).

## Back-compat note

The removed mixins had only 2 internal users (repo-wide grep). External plugins importing `SerialDeviceMixin`/`EthernetDeviceMixin` would break — say the word if deprecated aliases are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)