### PR TITLE
fix(m3): marshal off-main enable repaints; activate early diagnostics

### DIFF
--- a/pychron/core/helpers/m3_diagnostics.py
+++ b/pychron/core/helpers/m3_diagnostics.py
@@ -413,6 +413,51 @@ def install_thread_safe_marshalling() -> None:
     except Exception as e:  # pragma: no cover
         _log.error("marshalling: QTimer.singleShot patch failed: %s", e)
 
+    # --- enable.qt.base_window._Window._redraw -------------------------------
+    # THE universal Qt-paint chokepoint.  pychron's core helper Timer
+    # (pychron.core.helpers.timer.Timer) is a plain worker thread; several of
+    # its callbacks touch chaco/enable directly off the main thread:
+    #   motion_controller._inprogress_update -> canvas.set_stage_position
+    #   scanable_device._scan_ / scanner._scan -> graph.record
+    #   stream_graph_manager._update_scan_graph -> graph.record
+    # All of these funnel into enable's window._redraw, whose body calls
+    # ``self.control.update()`` -- a QWidget method that must run on the GUI
+    # thread.  On Apple Silicon (M3) an off-main update() faults (SIGSEGV/
+    # SIGBUS); Intel silently tolerates it.  This is a *separate* off-main Qt
+    # access from the QTimer-context bug handled above, so it needs its own
+    # marshalling.  Deferring the repaint one event-loop hop is harmless: the
+    # underlying data arrays are already mutated; update() only schedules a
+    # paint event.
+    _redraw_patched = False
+    for _modpath in ("enable.qt.base_window", "enable.qt4.base_window"):
+        try:
+            _mod = __import__(_modpath, fromlist=["_Window"])
+        except Exception:
+            continue
+        _Window = getattr(_mod, "_Window", None)
+        if _Window is None or not hasattr(_Window, "_redraw"):
+            continue
+        _orig_redraw = _Window._redraw
+
+        def _safe_redraw(self, coordinates=None, _orig=_orig_redraw):
+            if _on_main_thread():
+                return _orig(self, coordinates)
+            _log.debug(
+                "marshalling enable _redraw from %s",
+                threading.current_thread().name,
+            )
+            return _marshal(_orig, self, coordinates)
+
+        try:
+            _Window._redraw = _safe_redraw
+            patched.append("%s._Window._redraw" % _modpath)
+            _redraw_patched = True
+            break
+        except (TypeError, AttributeError) as e:  # pragma: no cover
+            _log.warning("marshalling: enable _redraw replacement rejected: %s", e)
+    if not _redraw_patched:
+        _log.warning("marshalling: enable window._redraw not patched (module not found)")
+
     _MARSHALLING_INSTALLED = True
     _log.info("thread-safe marshalling installed: %s", ", ".join(patched))
 

--- a/pychron/envisage/pychron_run.py
+++ b/pychron/envisage/pychron_run.py
@@ -300,6 +300,20 @@ def launch(klass):
     #         logger.critical('Login failed')
     #         return
 
+    # --- Phase 1 M3 diagnostics: install the Qt message handler and QTimer
+    # thread guard before any Qt object is constructed (i.e. before
+    # app_factory).  These are instrumentation only -- they capture
+    # cross-thread Qt timer/object warnings together with the originating
+    # Python stack so off-main violations are visible in the logs.  The
+    # functional fix (cross-thread marshalling) is installed later via
+    # install_late() once pyface is fully imported.
+    try:
+        from pychron.core.helpers.m3_diagnostics import install_early as _m3_install_early
+
+        _m3_install_early()
+    except Exception as _e:  # pragma: no cover
+        logger.warning("m3_diagnostics early install failed: %r", _e)
+
     # Register signal handler for SIGBUS (bus error, signal 10) to gracefully quit
     # instead of crashing
     signal.signal(signal.SIGBUS, _handle_bus_error)

--- a/pychron/hardware/core/scanable_device.py
+++ b/pychron/hardware/core/scanable_device.py
@@ -91,17 +91,11 @@ class ScanableDevice(ViewableDevice):
                     cast="boolean",
                     default=False,
                 )
-                self.set_attribute(
-                    config, "scan_period", "Scan", "period", cast="float"
-                )
+                self.set_attribute(config, "scan_period", "Scan", "period", cast="float")
                 self.set_attribute(config, "scan_width", "Scan", "width", cast="float")
                 self.set_attribute(config, "scan_units", "Scan", "units")
-                self.set_attribute(
-                    config, "record_scan_data", "Scan", "record", cast="boolean"
-                )
-                self.set_attribute(
-                    config, "graph_scan_data", "Scan", "graph", cast="boolean"
-                )
+                self.set_attribute(config, "record_scan_data", "Scan", "record", cast="boolean")
+                self.set_attribute(config, "graph_scan_data", "Scan", "graph", cast="boolean")
 
                 func = self.config_get(config, "Scan", "function", optional=True)
                 if func:
@@ -153,23 +147,22 @@ class ScanableDevice(ViewableDevice):
                         x = time.time()
 
                     ts = generate_datetimestamp()
-                    self.data_manager.write_to_frame(
-                        (ts, "{:<8s}".format("{:0.2f}".format(x))) + v
-                    )
+                    self.data_manager.write_to_frame((ts, "{:<8s}".format("{:0.2f}".format(x))) + v)
 
                 self._scan_hook(v)
 
             else:
                 """
-                scan func must return a value or we will stop the scan
-                since the timer runs on the main thread any long comms timeouts
-                slow user interaction
+                scan func must return a value or we will stop the scan.
+                The Timer runs this on a worker thread (NOT the main thread),
+                so comms reads here do not block the UI.  Any UI/graph updates
+                triggered by record() reach Qt through enable's window._redraw,
+                which m3_diagnostics marshals back to the main thread -- this is
+                required on Apple Silicon (M3) where an off-main repaint faults.
                 """
                 if self._no_response_counter > 3:
                     self.timer.Stop()
-                    self.info(
-                        "no response. stopping scan func={}".format(self.scan_func)
-                    )
+                    self.info("no response. stopping scan func={}".format(self.scan_func))
                     self._scanning = False
                     self._no_response_counter = 0
 
@@ -185,10 +178,7 @@ class ScanableDevice(ViewableDevice):
         """
         su = True
         if self._last_update:
-            if (
-                time.time() - self._last_update
-                < self.scan_period * self.time_dict[self.scan_units]
-            ):
+            if time.time() - self._last_update < self.scan_period * self.time_dict[self.scan_units]:
                 su = False
         self._last_update = time.time()
         return su


### PR DESCRIPTION
## Summary

Closes two remaining Apple Silicon (M3) segfault gaps in the timer/Qt-threading hardening. On M3, touching Qt off the main thread faults (SIGSEGV/SIGBUS); Intel silently tolerates the same code. Existing `m3_diagnostics` infra already marshalled pyface/QTimer scheduling, but two paths slipped through.

## What changed

**1. `install_early()` was dead code.** Defined in `m3_diagnostics.py`, documented "call as early as possible," but never called — so the Phase-1 Qt message handler (captures cross-thread timer/object warnings with originating Python stack) and the QTimer thread guard never ran. Now wired at the top of `launch()` in `pychron_run.py`, before `app_factory()` constructs any Qt object. Instrumentation only, no behavior change.

**2. Core `Timer` → graph/canvas repaint path was uncovered.** `pychron/core/helpers/timer.py` `Timer` is a plain worker `threading.Thread`. Several callbacks touch chaco/enable **directly off the main thread**, bypassing the existing marshalling:
- `motion_controller._inprogress_update` → `canvas.set_stage_position` → `invalidate_and_redraw`
- `scanable_device._scan_` / `scanner._scan` / `stream_graph_manager._update_scan_graph` → `graph.record` → `data.set_data`

All funnel into `enable.qt.base_window._Window._redraw` → `self.control.update()` — a QWidget call that must run on the GUI thread. This is a *separate* off-main access from the QTimer-context bug already handled, so it needs its own marshalling. `install_thread_safe_marshalling()` now patches `_Window._redraw`: off-main repaints defer to the main thread via `invoke_in_main_thread`; on-main calls are unchanged. Deferring is harmless — the data arrays are already mutated, `update()` only schedules a paint event. Patching the window is the single chokepoint covering all four offending timers.

**3. Stale comment fix.** `scanable_device._scan_` claimed "the timer runs on the main thread" — wrong (worker thread), and it masked this exact bug. Corrected.

## Reviewer notes

- `_Window._redraw` patch tries `enable.qt` then falls back to `enable.qt4`; logs a warning if neither is importable.
- Idempotent — `install_thread_safe_marshalling()` early-returns on second call (no double-wrap).
- Verified against the installed `enable` package: patch replaces `_redraw`; main-thread → direct call, worker-thread → marshalled exactly once; double-install does not re-wrap; `install_early()` runs clean (message handler + QTimer guard installed).
- Not exercised on real M3 hardware (no display/hardware in this environment) — logic verified, runtime paint behavior on-device not observed.
- Out of scope (not segfault sources, flagged for follow-up): `assert_main_thread` hardcodes `PyQt5` (breaks on PySide6 if ever called); SIGBUS handler does `sys.exit()` from a signal handler — `faulthandler` would aid future crash diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)