### PR TITLE
refactor(options): composition for limit/monitor state + preserve axis limits on rebuild

### DIFF
--- a/pychron/options/aux_plot.py
+++ b/pychron/options/aux_plot.py
@@ -24,22 +24,20 @@ from traits.api import (
     Property,
     on_trait_change,
     Dict,
-    Tuple,
     Enum,
     List,
     Any,
     Trait,
     Button,
+    Instance,
 )
 from traitsui.api import Color
+
 # ============= standard library imports ========================
 # ============= local library imports  ==========================
 from pychron.core.pychron_traits import FilterPredicate
+from pychron.options.axis_limits_state import AxisLimitsState, has_limits
 from pychron.pychron_constants import NULL_STR
-
-
-def has_limits(lims):
-    return lims is not None and lims[0] != lims[1]
 
 
 YTITLES = {
@@ -97,17 +95,23 @@ class AuxPlot(HasTraits):
     use_time_axis = False
     initialized = False
 
+    # fixed, user-entered limits (edited in the options UI)
     ymin = Float
     ymax = Float
     xmin = Float
     xmax = Float
 
-    ylimits = Tuple(Float, Float, transient=True)
-    xlimits = Tuple(Float, Float, transient=True)
+    # captured view-limit state, composed one per axis
+    _xstate = Instance(AxisLimitsState, (), transient=True)
+    _ystate = Instance(AxisLimitsState, (), transient=True)
+
+    # backward-compatible surface delegating to the composed state objects
+    xlimits = Property(transient=True)
+    ylimits = Property(transient=True)
+    _has_xlimits = Property(transient=True)
+    _has_ylimits = Property(transient=True)
 
     overlay_positions = Dict(transient=True)
-    _has_ylimits = Bool(False, transient=True)
-    _has_xlimits = Bool(False, transient=True)
 
     marker = Str("circle")
     marker_size = Float(2)
@@ -135,30 +139,57 @@ class AuxPlot(HasTraits):
         self.overlay_positions[k] = v
 
     def has_xlimits(self):
-        return self._has_xlimits or has_limits(self.xlimits)
+        return self._xstate.has()
 
     def has_ylimits(self):
-        return self._has_ylimits or has_limits(self.ylimits)
+        return self._ystate.has()
 
     def has_fixed_ylimits(self):
         return self.ymin or self.ymax
+
+    def capture_limits(self, xlims=None, ylims=None):
+        """Record the current view limits so a rebuild can restore them."""
+        if xlims is not None:
+            self._xstate.capture(xlims)
+        if ylims is not None:
+            self._ystate.capture(ylims)
 
     @on_trait_change("clear_ylimits_button")
     def handle_clear_ylimits(self):
         self.ymin, self.ymax = 0, 0
         self.clear_ylimits()
-        # self.ylimits = (self.ymin, self.ymax)
-        # self._has_ylimits = has_limits(self.ylimits)
 
     def clear_ylimits(self):
-        # self.ymin, self.ymax = 0, 0
-        self.ylimits = (self.ymin, self.ymax)
-        self._has_ylimits = has_limits(self.ylimits)
+        # reset the view to the fixed ymin/ymax (does not touch ymin/ymax)
+        self._ystate.reset((self.ymin, self.ymax))
 
     def clear_xlimits(self):
         self.xmin, self.xmax = 0, 0
-        self.xlimits = (self.xmin, self.xmax)
-        self._has_xlimits = has_limits(self.xlimits)
+        self._xstate.reset((self.xmin, self.xmax))
+
+    def _get_xlimits(self):
+        return self._xstate.limits
+
+    def _set_xlimits(self, v):
+        self._xstate.limits = v
+
+    def _get_ylimits(self):
+        return self._ystate.limits
+
+    def _set_ylimits(self, v):
+        self._ystate.limits = v
+
+    def _get__has_xlimits(self):
+        return self._xstate.explicit
+
+    def _set__has_xlimits(self, v):
+        self._xstate.explicit = v
+
+    def _get__has_ylimits(self):
+        return self._ystate.explicit
+
+    def _set__has_ylimits(self, v):
+        self._ystate.explicit = v
 
     def _name_changed(self):
         if self.initialized:

--- a/pychron/options/axis_limits_state.py
+++ b/pychron/options/axis_limits_state.py
@@ -1,0 +1,54 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+View-limit state for a single plot axis.
+
+Extracted from AuxPlot as a composed value object. AuxPlot used to inline the
+captured-view limits as parallel transient traits (``xlimits`` + ``_has_xlimits``
+and the ``ylimits`` pair). Bundling each axis's view state here makes the unit
+explicit, independently testable, and gives the rebuild path a clear
+capture / reset vocabulary so a figure rebuild can preserve the user's current
+pan/zoom instead of silently dropping it.
+"""
+from traits.api import HasTraits, Bool, Tuple, Float
+
+
+def has_limits(lims):
+    return lims is not None and lims[0] != lims[1]
+
+
+class AxisLimitsState(HasTraits):
+    # the captured view limits (lo, hi). Transient: a view, never serialized.
+    limits = Tuple(Float, Float, transient=True)
+    # explicitly flagged as set even if lo == hi
+    explicit = Bool(False, transient=True)
+
+    def capture(self, lims):
+        """Record the current view limits (e.g. after a user pan/zoom)."""
+        self.limits = tuple(lims)
+        self.explicit = has_limits(lims)
+
+    def reset(self, fixed=(0.0, 0.0)):
+        """Drop the captured view, falling back to the given fixed limits."""
+        self.limits = tuple(fixed)
+        self.explicit = has_limits(fixed)
+
+    def has(self):
+        """True if a usable view/fixed limit is present."""
+        return self.explicit or has_limits(self.limits)
+
+
+# ============= EOF =============================================

--- a/pychron/options/flux.py
+++ b/pychron/options/flux.py
@@ -16,9 +16,9 @@
 
 # ============= enthought library imports =======================
 from traits.api import Str, Int, Enum, Property, Bool, Float, HasTraits
-from uncertainties import ufloat
 
 from pychron.options.aux_plot import AuxPlot
+from pychron.options.monitor_constants import MonitorConstants
 from pychron.options.options import FigureOptions
 from pychron.pychron_constants import (
     FLUX_CONSTANTS,
@@ -73,19 +73,16 @@ class MonitorMixin(HasTraits):
     monitor_material = Property(depends_on="selected_monitor")
 
     def _get_lambda_k(self):
-        dc = FLUX_CONSTANTS[self.selected_monitor]
-        b = ufloat(*dc["lambda_b"])
-        ec = ufloat(*dc["lambda_ec"])
-        return b + ec
+        return MonitorConstants(self.selected_monitor).lambda_k
 
     def _get_monitor_name(self):
-        return FLUX_CONSTANTS[self.selected_monitor].get("monitor_name", "")
+        return MonitorConstants(self.selected_monitor).monitor_name
 
     def _get_monitor_age(self):
-        return FLUX_CONSTANTS[self.selected_monitor].get("monitor_age", 0)
+        return MonitorConstants(self.selected_monitor).monitor_age
 
     def _get_monitor_material(self):
-        return FLUX_CONSTANTS[self.selected_monitor].get("monitor_material", "")
+        return MonitorConstants(self.selected_monitor).monitor_material
 
 
 class FluxOptions(BaseFluxOptions, MonitorMixin):

--- a/pychron/options/monitor_constants.py
+++ b/pychron/options/monitor_constants.py
@@ -1,0 +1,56 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+Flux-monitor constant resolution.
+
+Extracted from MonitorMixin as a composed value object. The mixin mixed
+UI-bound Enums (``selected_monitor``, ``error_kind``) with knowledge of the
+FLUX_CONSTANTS schema. The schema lookups live here now -- a small, dependency-
+free object that can be unit-tested without constructing a traits Options
+object -- and the mixin's Properties delegate to it.
+"""
+from uncertainties import ufloat
+
+from pychron.pychron_constants import FLUX_CONSTANTS
+
+
+class MonitorConstants:
+    """Resolves the constants for a single flux monitor key."""
+
+    def __init__(self, key):
+        # mirrors the previous behavior: an unknown key raises KeyError
+        self._dc = FLUX_CONSTANTS[key]
+
+    @property
+    def lambda_k(self):
+        b = ufloat(*self._dc["lambda_b"])
+        ec = ufloat(*self._dc["lambda_ec"])
+        return b + ec
+
+    @property
+    def monitor_name(self):
+        return self._dc.get("monitor_name", "")
+
+    @property
+    def monitor_age(self):
+        return self._dc.get("monitor_age", 0)
+
+    @property
+    def monitor_material(self):
+        return self._dc.get("monitor_material", "")
+
+
+# ============= EOF =============================================

--- a/pychron/options/tests/aux_plot_limits_test.py
+++ b/pychron/options/tests/aux_plot_limits_test.py
@@ -1,0 +1,84 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+AuxPlot now composes two AxisLimitsState objects. These pin the backward-
+compatible surface (xlimits / ylimits / _has_xlimits / _has_ylimits and the
+has_* / clear_* methods) plus the new capture_limits API, and the asymmetric
+clear semantics (clear_ylimits keeps ymin/ymax; clear_xlimits zeroes xmin/xmax).
+"""
+import unittest
+
+from pychron.options.aux_plot import AuxPlot
+
+
+class AuxPlotLimitsTestCase(unittest.TestCase):
+    def test_starts_without_limits(self):
+        a = AuxPlot()
+        self.assertFalse(a.has_xlimits())
+        self.assertFalse(a.has_ylimits())
+
+    def test_xlimits_property_roundtrip(self):
+        a = AuxPlot()
+        a.xlimits = (10, 20)
+        self.assertEqual(a.xlimits, (10, 20))
+        self.assertTrue(a.has_xlimits())
+
+    def test_has_flag_property_roundtrip(self):
+        a = AuxPlot()
+        a._has_xlimits = True
+        self.assertTrue(a.has_xlimits())
+
+    def test_capture_limits(self):
+        a = AuxPlot()
+        a.capture_limits(xlims=(1, 2), ylims=(3, 4))
+        self.assertEqual(a.xlimits, (1, 2))
+        self.assertEqual(a.ylimits, (3, 4))
+        self.assertTrue(a.has_xlimits())
+        self.assertTrue(a.has_ylimits())
+
+    def test_clear_ylimits_resets_to_fixed_and_keeps_ymin_ymax(self):
+        a = AuxPlot()
+        a.ymin, a.ymax = 5, 50
+        a.capture_limits(ylims=(11, 22))
+        a.clear_ylimits()
+        self.assertEqual(a.ylimits, (5, 50))
+        self.assertEqual((a.ymin, a.ymax), (5, 50))
+
+    def test_clear_xlimits_zeroes_fixed_bounds(self):
+        a = AuxPlot()
+        a.xmin, a.xmax = 5, 50
+        a.capture_limits(xlims=(11, 22))
+        a.clear_xlimits()
+        self.assertEqual(a.xlimits, (0, 0))
+        self.assertEqual((a.xmin, a.xmax), (0, 0))
+        self.assertFalse(a.has_xlimits())
+
+    def test_instances_do_not_share_state(self):
+        a = AuxPlot()
+        b = AuxPlot()
+        a.capture_limits(xlims=(1, 2))
+        self.assertFalse(b.has_xlimits())
+
+    def test_view_limits_excluded_from_to_dict(self):
+        a = AuxPlot()
+        a.capture_limits(xlims=(1, 2), ylims=(3, 4))
+        d = a.to_dict()
+        self.assertNotIn("xlimits", d)
+        self.assertNotIn("ylimits", d)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/options/tests/axis_limits_state_test.py
+++ b/pychron/options/tests/axis_limits_state_test.py
@@ -1,0 +1,76 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+import unittest
+
+from pychron.options.axis_limits_state import AxisLimitsState, has_limits
+
+
+class HasLimitsTestCase(unittest.TestCase):
+    def test_none(self):
+        self.assertFalse(has_limits(None))
+
+    def test_equal_is_not_limits(self):
+        self.assertFalse(has_limits((5, 5)))
+
+    def test_distinct_is_limits(self):
+        self.assertTrue(has_limits((0, 10)))
+
+
+class AxisLimitsStateTestCase(unittest.TestCase):
+    def test_starts_empty(self):
+        s = AxisLimitsState()
+        self.assertFalse(s.has())
+
+    def test_capture_sets_limits_and_has(self):
+        s = AxisLimitsState()
+        s.capture((1, 9))
+        self.assertEqual(s.limits, (1, 9))
+        self.assertTrue(s.has())
+
+    def test_capture_equal_bounds_is_not_has(self):
+        s = AxisLimitsState()
+        s.capture((4, 4))
+        self.assertFalse(s.has())
+
+    def test_reset_to_fixed(self):
+        s = AxisLimitsState()
+        s.capture((1, 9))
+        s.reset((2, 8))
+        self.assertEqual(s.limits, (2, 8))
+        self.assertTrue(s.has())
+
+    def test_reset_default_clears(self):
+        s = AxisLimitsState()
+        s.capture((1, 9))
+        s.reset()
+        self.assertEqual(s.limits, (0, 0))
+        self.assertFalse(s.has())
+
+    def test_explicit_flag_forces_has(self):
+        s = AxisLimitsState()
+        s.limits = (3, 3)
+        s.explicit = True
+        self.assertTrue(s.has())
+
+    def test_instances_are_independent(self):
+        a = AxisLimitsState()
+        b = AxisLimitsState()
+        a.capture((1, 2))
+        self.assertFalse(b.has())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/options/tests/monitor_constants_test.py
+++ b/pychron/options/tests/monitor_constants_test.py
@@ -1,0 +1,65 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+import unittest
+
+from pychron.options.monitor_constants import MonitorConstants
+from pychron.pychron_constants import FLUX_CONSTANTS
+
+
+class MonitorConstantsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.key = list(FLUX_CONSTANTS.keys())[0]
+        self.dc = FLUX_CONSTANTS[self.key]
+
+    def test_unknown_key_raises(self):
+        with self.assertRaises(KeyError):
+            MonitorConstants("not-a-real-monitor")
+
+    def test_name_age_material(self):
+        mc = MonitorConstants(self.key)
+        self.assertEqual(mc.monitor_name, self.dc.get("monitor_name", ""))
+        self.assertEqual(mc.monitor_age, self.dc.get("monitor_age", 0))
+        self.assertEqual(mc.monitor_material, self.dc.get("monitor_material", ""))
+
+    def test_lambda_k_is_sum_of_beta_and_ec(self):
+        mc = MonitorConstants(self.key)
+        lk = mc.lambda_k
+        expected = self.dc["lambda_b"][0] + self.dc["lambda_ec"][0]
+        self.assertAlmostEqual(lk.nominal_value, expected)
+
+    def test_defaults_for_sparse_entry(self):
+        # find a key missing optional fields, if any; otherwise this is a no-op
+        for k, dc in FLUX_CONSTANTS.items():
+            if "monitor_name" not in dc:
+                mc = MonitorConstants(k)
+                self.assertEqual(mc.monitor_name, "")
+                break
+
+
+class MonitorMixinDelegationTestCase(unittest.TestCase):
+    def test_flux_options_properties_match_resolver(self):
+        from pychron.options.flux import FluxOptions
+
+        fo = FluxOptions()
+        mc = MonitorConstants(fo.selected_monitor)
+        self.assertEqual(fo.monitor_age, mc.monitor_age)
+        self.assertEqual(fo.monitor_name, mc.monitor_name)
+        self.assertEqual(fo.monitor_material, mc.monitor_material)
+        self.assertEqual(fo.lambda_k.nominal_value, mc.lambda_k.nominal_value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/pipeline/plot/figure_container.py
+++ b/pychron/pipeline/plot/figure_container.py
@@ -41,14 +41,16 @@ class FigureContainer(HasTraits):
     cols = Int
 
     def refresh(self, clear: bool = False) -> None:
-        logger.debug(f"FigureContainer.refresh() called with clear={clear}, rows={self.rows}, cols={self.cols}")
+        logger.debug(
+            f"FigureContainer.refresh() called with clear={clear}, rows={self.rows}, cols={self.cols}"
+        )
         comp = self.component
         if clear and hasattr(comp, "components"):
             logger.debug("Clearing component.components")
             del comp.components[:]
 
         # Reset the panel generator before iterating, in case it was exhausted from a previous iteration
-        if self.model and hasattr(self.model, 'reset_panel_gen'):
+        if self.model and hasattr(self.model, "reset_panel_gen"):
             self.model.reset_panel_gen()
 
         for i in range(self.rows):
@@ -63,10 +65,10 @@ class FigureContainer(HasTraits):
                 graph = p.make_graph((i, self.rows), (j, self.cols))
                 logger.debug(f"Adding graph from panel ({i}, {j}): {graph}")
                 comp.add(graph)
-                if clear and hasattr(p.plot_options, "aux_plots"):
-                    for ap in p.plot_options.aux_plots:
-                        ap.clear_ylimits()
-                        ap.clear_xlimits()
+                # NOTE: do not clear aux-plot view limits here. A rebuild
+                # (e.g. an options change) must preserve the user's current
+                # pan/zoom. View limits are reset only on a genuine data change,
+                # via FigureEditor.set_items -> clear_aux_plot_limits.
 
         if hasattr(comp, "invalidate_and_redraw"):
             logger.debug("Calling comp.invalidate_and_redraw()")
@@ -77,7 +79,9 @@ class FigureContainer(HasTraits):
         logger.debug("FigureContainer.refresh() complete")
 
     def model_changed(self, clear: bool = True, refresh_panels: bool = True) -> None:
-        logger.debug(f"FigureContainer.model_changed() called with clear={clear}, refresh_panels={refresh_panels}")
+        logger.debug(
+            f"FigureContainer.model_changed() called with clear={clear}, refresh_panels={refresh_panels}"
+        )
         layout = self.model.plot_options.layout
         if refresh_panels:
             logger.debug("Calling model.refresh_panels()")

--- a/pychron/pipeline/tests/figure_container_limits_test.py
+++ b/pychron/pipeline/tests/figure_container_limits_test.py
@@ -1,0 +1,102 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+Regression test: a figure rebuild must NOT reset the user's axis limits.
+
+Previously FigureContainer.refresh(clear=True) called clear_ylimits/clear_xlimits
+on every aux_plot, so any rebuild (e.g. an options change) discarded the user's
+current pan/zoom. The view limits are now only reset on a genuine data change
+(FigureEditor.set_items), so refresh must leave captured limits intact.
+"""
+import unittest
+
+from pychron.options.aux_plot import AuxPlot
+from pychron.pipeline.plot.figure_container import FigureContainer
+
+
+class _FakeComponent:
+    def __init__(self):
+        self.components = []
+        self.redrawn = False
+
+    def add(self, g):
+        self.components.append(g)
+
+    def invalidate_and_redraw(self):
+        self.redrawn = True
+
+
+class _FakePlotOptions:
+    def __init__(self, aux_plots):
+        self.aux_plots = aux_plots
+
+
+class _FakePanel:
+    def __init__(self, aux_plots):
+        self.plot_options = _FakePlotOptions(aux_plots)
+        self.graphs = 0
+
+    def make_graph(self, row, col):
+        self.graphs += 1
+        return object()
+
+
+class _FakeModel:
+    def __init__(self, panel):
+        self._panel = panel
+        self._served = False
+
+    def reset_panel_gen(self):
+        self._served = False
+
+    def next_panel(self):
+        if self._served:
+            raise StopIteration
+        self._served = True
+        return self._panel
+
+
+class FigureContainerLimitsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.ap = AuxPlot()
+        self.ap.capture_limits(xlims=(10, 20), ylims=(1, 9))
+        self.panel = _FakePanel([self.ap])
+        self.container = FigureContainer()
+        # set without notification: avoid the _model_changed handler, which
+        # would need a fully-formed plot_options/layout. We exercise refresh()
+        # directly.
+        self.container.trait_setq(
+            model=_FakeModel(self.panel),
+            component=_FakeComponent(),
+            rows=1,
+            cols=1,
+        )
+
+    def test_rebuild_preserves_view_limits(self):
+        self.container.refresh(clear=True)
+
+        # the graph was rebuilt ...
+        self.assertEqual(self.panel.graphs, 1)
+        self.assertTrue(self.container.component.redrawn)
+        # ... but the user's captured limits survived
+        self.assertEqual(self.ap.xlimits, (10, 20))
+        self.assertEqual(self.ap.ylimits, (1, 9))
+        self.assertTrue(self.ap.has_xlimits())
+        self.assertTrue(self.ap.has_ylimits())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Composition refactor of the options / plotter-options layer, with a concrete bug fix: **axis limits no longer reset when a figure is rebuilt** (e.g. on an options change). Two self-contained commits.

### 1. AxisLimitsState + preserve limits on rebuild (`50866aac2`)

`AuxPlot` inlined per-axis view-limit bookkeeping as parallel transient traits (`xlimits`+`_has_xlimits`, `ylimits`+`_has_ylimits`) with asymmetric clear logic.

- Extracted each axis's view state into a composed [`AxisLimitsState`](pychron/options/axis_limits_state.py) value object (`capture` / `reset` / `has`). `AuxPlot` holds one per axis and exposes the old `xlimits`/`ylimits`/`_has_*` surface as delegating properties, plus a new explicit `capture_limits()`. Clear semantics preserved exactly (`clear_ylimits` keeps `ymin/ymax`; `clear_xlimits` zeroes `xmin/xmax`).
- **Bug fix:** `FigureContainer.refresh(clear=True)` called `clear_*limits()` on every aux_plot, so *any* rebuild discarded the user's pan/zoom. View limits are now reset **only on a genuine data change** (`FigureEditor.set_items → clear_aux_plot_limits`); a rebuild leaves captured limits intact (they take priority over recalculated limits in `_get_plot_y_limits`).

### 2. MonitorConstants resolver (`e22017228`)

`MonitorMixin` mixed UI-bound Enums with direct FLUX_CONSTANTS schema knowledge. Moved the lookups into a composed, dependency-light [`MonitorConstants`](pychron/options/monitor_constants.py); the mixin keeps its UI traits and its Properties delegate, so the flux / vertical-flux TraitsUI views are unaffected. Now unit-testable standalone.

## Scope note (deliberate)

`GroupMixin` and `JErrorMixin` are intentionally **left as mixins**: their traits are UI-bound and (for `JErrorMixin`) `dumpable`/persisted, so converting them to composed sub-objects would break views/serialization for no real gain. Each concrete options class uses at most one mixin (no diamond) — the real composition wins here are the logic bits (limit view-state, constant resolution), which are what got extracted.

## Tests

New `pychron/options/tests/` suite + a pipeline regression test (all headless):
- `axis_limits_state_test.py` — capture/reset/has semantics
- `aux_plot_limits_test.py` — AuxPlot delegation, clear-semantics asymmetry, to_dict exclusion
- `monitor_constants_test.py` — FLUX_CONSTANTS resolution + FluxOptions delegation
- `figure_container_limits_test.py` — **regression: a rebuild preserves captured limits**

All pass; the pre-existing `figure_panel_limits_test` still passes. Options discovery: 23 tests green.

## Verification

- 23 options tests + 4 limits tests pass; no new regressions.
- `FluxOptions.lambda_k`/`monitor_age` resolve identically; flux views unaffected.
- 3 failures in `figure_model_test`/`grid_axis_visibility_test` are **pre-existing on `main`** (confirmed via stash) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)