### PR TITLE
fix(pipeline): repair figure refresh sync and grid-axis padding (red tests on main)

### DIFF
--- a/pychron/pipeline/plot/models/figure_model.py
+++ b/pychron/pipeline/plot/models/figure_model.py
@@ -52,6 +52,11 @@ class FigureModel(HasTraits):
             panels_rebuilt = self.refresh_panels(force=True)
         elif self._panels_need_refresh():
             panels_rebuilt = self.refresh_panels()
+        elif self.panels:
+            # topology unchanged: reuse the existing panels but push the new
+            # analyses into them so reused figures don't keep stale data
+            self._sync_panels()
+            self.reset_panel_gen()
 
         for p in self.panels:
             if not p.figures or force:
@@ -100,9 +105,7 @@ class FigureModel(HasTraits):
     def _make_panel_groups(self):
         if self.analysis_groups:
             gs = [
-                self._panel_factory(
-                    analyses=ag, plot_options=self.plot_options, graph_id=gid
-                )
+                self._panel_factory(analyses=ag, plot_options=self.plot_options, graph_id=gid)
                 for gid, ag in enumerate(self.analysis_groups)
             ]
         else:

--- a/pychron/pipeline/plot/plotter/arar_figure.py
+++ b/pychron/pipeline/plot/plotter/arar_figure.py
@@ -148,7 +148,7 @@ class BaseArArFigure(SelectionFigure):
         layout = self.options.layout
         fw = layout.fixed_width
         fh = layout.fixed_height
-        
+
         print(f"[arar_figure.make_plots] fw={fw}, fh={fh}")
 
         # stretch_vertical = layout.stretch_vertical
@@ -284,17 +284,10 @@ class BaseArArFigure(SelectionFigure):
         options = self.options
         show_all_axes = bool(getattr(options, "show_all_axes", True))
 
-        # print('aaa', pp.padding_left, pp.width, pp.outer_width)
+        # interior columns get a narrower left padding, unless the user has
+        # asked to keep all axes visible
         if col[0] > 0 and not show_all_axes:
             pp.padding_left = max(20, int(pp.padding_left * 0.5))
-
-        # print('bbb', pp.padding_left, pp.width, pp.outer_width)
-
-        # print('aaa', pp.padding_left, pp.width, pp.outer_width)
-        if col[0] > 0:
-            pp.padding_left = max(20, int(pp.padding_left * 0.5))
-
-        # print('bbb', pp.padding_left, pp.width, pp.outer_width)
 
         pp.bgcolor = options.plot_bgcolor
         pp.x_grid.visible = options.use_xgrid
@@ -306,9 +299,7 @@ class BaseArArFigure(SelectionFigure):
                 try:
                     setattr(axis, attr, value)
                 except TraitError as e:
-                    logger.warning(
-                        "error setting attr={},value={} error={}".format(attr, value, e)
-                    )
+                    logger.warning("error setting attr={},value={} error={}".format(attr, value, e))
 
             axis.tick_label_font = getattr(options, "{}tick_font".format(k))
 
@@ -326,9 +317,7 @@ class BaseArArFigure(SelectionFigure):
 
             if po.yticks_both_sides:
                 if self.group_id == 0 and self.subgroup_id == 0:
-                    alt_axis = PlotAxis(
-                        pp, orientation="left" if po.y_axis_right else "right"
-                    )
+                    alt_axis = PlotAxis(pp, orientation="left" if po.y_axis_right else "right")
                     alt_axis.tick_label_formatter = lambda x: ""
                     alt_axis.axis_line_visible = False
                     alt_axis.tick_in = options.ytick_in
@@ -345,11 +334,7 @@ class BaseArArFigure(SelectionFigure):
                 if alt_axis and not po.ytitle_visible:
                     alt_axis.tick_visible = False
             else:
-                if (
-                    po.has_fixed_ylimits()
-                    and col[0] > 0
-                    and not show_all_axes
-                ):
+                if po.has_fixed_ylimits() and col[0] > 0 and not show_all_axes:
                     pp.y_axis.tick_label_formatter = lambda x: ""
 
                 pp.value_scale = po.scale
@@ -386,9 +371,7 @@ class BaseArArFigure(SelectionFigure):
     def _cmp_analyses(self, x):
         return x.timestamp or 0
 
-    def _unpack_attr(
-        self, attr, scalar=1, exclude_omit=False, nonsorted=False, ans=None
-    ):
+    def _unpack_attr(self, attr, scalar=1, exclude_omit=False, nonsorted=False, ans=None):
         if ans is None:
             ans = self.sorted_analyses
 
@@ -414,9 +397,7 @@ class BaseArArFigure(SelectionFigure):
 
         ma = max_ if max_ is not None else max(ma, b)
 
-        self.graph.set_y_limits(
-            min_=mi, max_=ma, pad=pad, plotid=pid, pad_style="upper"
-        )
+        self.graph.set_y_limits(min_=mi, max_=ma, pad=pad, plotid=pid, pad_style="upper")
 
     def update_options_limits(self, pid):
         if not self.suppress_xlimits_update:
@@ -642,9 +623,7 @@ class BaseArArFigure(SelectionFigure):
                     additional_info=additional_info,
                 )
 
-                pinspector_overlay = PointInspectorOverlay(
-                    component=scatter, tool=inspector
-                )
+                pinspector_overlay = PointInspectorOverlay(component=scatter, tool=inspector)
                 scatter.overlays.append(pinspector_overlay)
                 # broadcaster.tools.append(inspector)
                 scatter.tools.append(inspector)
@@ -711,7 +690,7 @@ class BaseArArFigure(SelectionFigure):
         label_position="top right",
         color=None,
         append=True,
-        **kw
+        **kw,
     ):
         if color is None:
             color = s.color
@@ -729,7 +708,7 @@ class BaseArArFigure(SelectionFigure):
             # setting the arrow to visible causes an error when reading with illustrator
             # if the arrow is not drawn
             arrow_visible=False,
-            **kw
+            **kw,
         )
         s.overlays.append(label)
         tool = DataLabelTool(label)
@@ -788,9 +767,7 @@ class BaseArArFigure(SelectionFigure):
             age_units = self._get_age_units()
             pe = ""
             if percent_error:
-                pe = "({})".format(
-                    format_percent_error(x, we, include_percent_sign=True)
-                )
+                pe = "({})".format(format_percent_error(x, we, include_percent_sign=True))
 
             me = "{} {} {}{} {}".format(sx, PLUSMINUS, swe, pe, age_units)
 
@@ -839,9 +816,7 @@ class BaseArArFigure(SelectionFigure):
     # ===============================================================================
     @cached_property
     def _get_sorted_analyses(self):
-        return sorted(
-            self.analyses, key=self._cmp_analyses, reverse=self._reverse_sorted_analyses
-        )
+        return sorted(self.analyses, key=self._cmp_analyses, reverse=self._reverse_sorted_analyses)
 
     @cached_property
     def _get_analysis_group(self):


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs on `main` whose unit tests were committed already failing (3 red tests). Both are small, surgical fixes; the tests were correct and now pass.

### 1. `figure_model.refresh()` — stale analyses on same-topology refresh

When the panel topology was unchanged, `refresh()` (non-force) called neither `refresh_panels` nor `_sync_panels`, so reused figures kept their **stale analyses** — a benign refresh did not pick up new data. `_sync_panels` (which pushes new analyses into reused panels) was unreachable in this path because `force_refresh_panels` defaults to `True`.

Added the missing branch: topology unchanged → `_sync_panels()` + `reset_panel_gen()`. Fixes `figure_model_test.test_refresh_reuses_panels_when_topology_is_same`.

### 2. `arar_figure._apply_aux_plot_options()` — duplicated padding halving

A duplicated, **unguarded** `padding_left` halving (a debug/merge leftover, flanked by commented `print`s) ran whenever `col[0] > 0`, ignoring `show_all_axes`. Effect: interior left padding was double-halved in the default case (→25 instead of 50) and shrunk even when the user set `show_all_axes` (→50 instead of 100). Removed the duplicate so padding is halved once, only for interior columns when not `show_all_axes`. Fixes both `grid_axis_visibility_test` padding assertions.

## Verification

`figure_model_test`, `grid_axis_visibility_test`, `figure_panel_limits_test`, and `import_hygiene_test` all pass (15 tests). Was 3 failing before.

## Note

`arar_figure.build()` still contains a stray debug `print(f"[arar_figure.make_plots] ...")` (unrelated to these fixes) — worth removing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)